### PR TITLE
Evolver revamp

### DIFF
--- a/docs/doxyfile.conf
+++ b/docs/doxyfile.conf
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./pages ./examples ../ ../src/isle ../src/isle/cpp ../src/isle/cpp/bind ../src/isle/cpp/action ../src/isle/meas ../src/isle/action ../src/isle/drivers ../src/isle/scripts ../src/isle/evolver
+INPUT                  = ./pages ./examples ../ ../src/isle ../src/isle/cpp ../src/isle/cpp/bind ../src/isle/cpp/action ../src/isle/meas ../src/isle/action ../src/isle/drivers ../src/isle/scripts ../src/isle/evolver ../src/isle/evolver/transform
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/examples/changeEvolver.py
+++ b/docs/examples/changeEvolver.py
@@ -57,7 +57,7 @@ def main():
     # This reads the indicated checkpoint (latest by default) from the file
     # and extracts the save and checkpoint frequencies based on how often data
     # was saved / checkpointed to the file before.
-    hmcState, phi, evolver, \
+    hmcState, evStage, evolver, \
         saveFreq, checkpointFreq = isle.drivers.hmc.continueRun(args.infile, args.outfile,
                                                                 args.initial, args.overwrite)
 
@@ -73,7 +73,7 @@ def main():
 
     # Run the driver with the input data and user specified parameters.
     getLogger(__name__).info("Starting evolution")
-    hmcState(phi, evolver, args.ntrajectories,
+    hmcState(evStage, evolver, args.ntrajectories,
              saveFreq=saveFreq, checkpointFreq=checkpointFreq)
 
 

--- a/docs/examples/fullHMCEvolution.py
+++ b/docs/examples/fullHMCEvolution.py
@@ -110,7 +110,7 @@ def main():
     # The number of steps (99) must be one less than the number of trajectories below.
     evolver = isle.evolver.LinearStepLeapfrog(hmcState.action, (1, 1), (20, 5), 99, rng)
     # Thermalize configuration for 100 trajectories without saving anything.
-    phi, *_ = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
+    evStage = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
     # Reset the internal counter so we start saving configs at index 0.
     hmcState.resetIndex()
 
@@ -120,7 +120,7 @@ def main():
     evolver = isle.evolver.ConstStepLeapfrog(hmcState.action, 1, 5, rng)
     # Produce configurations and save in intervals of 2 trajectories.
     # Place a checkpoint every 10 trajectories.
-    phi, *_ = hmcState(phi, evolver, 100, saveFreq=2, checkpointFreq=10)
+    hmcState(evStage, evolver, 100, saveFreq=2, checkpointFreq=10)
 
     # That is it, clean up happens automatically.
 

--- a/docs/examples/mpiTuning.py
+++ b/docs/examples/mpiTuning.py
@@ -134,7 +134,7 @@ def tuneForEnsemble(latticeYAML, paramsYAML, clArgs):
     # The number of steps (99) must be one less than the number of trajectories below.
     evolver = isle.evolver.LinearStepLeapfrog(hmcState.action, (1, 1), (20, 5), 99, rng)
     # Thermalize configuration for 100 trajectories without saving anything.
-    phi, *_ = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
+    stage = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
     # Reset the internal counter so we start saving configs at index 0.
     hmcState.resetIndex()
 
@@ -143,7 +143,7 @@ def tuneForEnsemble(latticeYAML, paramsYAML, clArgs):
     # constructor for a list of all supported parameters.
     evolver = isle.evolver.LeapfrogTuner(hmcState.action, 1, 1, rng, outputFile)
     # Run evolution with the tuner for an indefinite number of trajectories,
-    hmcState(phi, evolver, None, saveFreq=1, checkpointFreq=0)
+    hmcState(stage, evolver, None, saveFreq=1, checkpointFreq=0)
 
 
 def main():

--- a/docs/examples/tuning.py
+++ b/docs/examples/tuning.py
@@ -108,7 +108,7 @@ def tune(rng):
     # The number of steps (99) must be one less than the number of trajectories below.
     evolver = isle.evolver.LinearStepLeapfrog(hmcState.action, (1, 1), (20, 5), 99, rng)
     # Thermalize configuration for 100 trajectories without saving anything.
-    phi, *_ = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
+    evStage = hmcState(phi, evolver, 100, saveFreq=0, checkpointFreq=0)
     # Reset the internal counter so we start saving configs at index 0.
     hmcState.resetIndex()
 
@@ -123,7 +123,7 @@ def tune(rng):
     # Run evolution with the tuner for an indefinite number of trajectories,
     # LeapfrogTuner is in charge of terminating the run.
     # Checkpointing is not supported by the tuner, so checkpointFreq must be 0.
-    hmcState(phi, evolver, None, saveFreq=1, checkpointFreq=0)
+    hmcState(evStage, evolver, None, saveFreq=1, checkpointFreq=0)
 
 
 def produce(rng):
@@ -149,7 +149,7 @@ def produce(rng):
     # to continue from, so load configuration and evolver manually.
     with h5.File(TUNEFILE, "r") as h5f:
         # Load the last saved configuration.
-        phi, *_ = isle.h5io.loadConfiguration(h5f)
+        phi, _ = isle.h5io.loadConfiguration(h5f)
         # Construct a ConstStepLeapfrog evolver from tuned parameters.
         evolver = isle.evolver.LeapfrogTuner.loadTunedEvolver(h5f, hmcState.action, rng)
 

--- a/docs/pages/evolvers.md
+++ b/docs/pages/evolvers.md
@@ -1,5 +1,7 @@
 \page evolversdoc Evolvers
 
+\todo documen transforms
+
 Evolvers are the main component of HMC evolution.
 Their task is transforming one configuration into another one along the Markov chain.
 
@@ -28,6 +30,19 @@ Another example is isle.evolver.hubbard.TwoPiJumps which generates discrete shif
 configuration and uses knowledge of the action of the Hubbard model to compute the change in energy.
 It can do multiple updates and accept or reject each one individually all encapsulated
 in one call to `evolve`.
+
+Evolvers have to operate as mostly closed off units and can only communicate by means of
+the interface of the `evolve` method as mediated by the HMC driver.
+The argument and return value of `evolve`, isle.evolver.stage.EvolutionStage, allows
+storing custom MC weights in addition to the action.
+On top of this, there is a facility to store arbitrary data (as long as it can be written to HDF5)
+in the '`extra`' attribute.
+For both special cases it is important to keep in mind that users might use evolvers in ways
+not expected by the author.
+It is therefore advised to guard any usage of `EvolutionStage.logWeights` and
+`EvolutionStage.extra` to make sure MCMC proceeds correctly.
+As a good practice, all evolvers should use the `accept` and `reject` methods of
+`EvolutionStage` to clear out any unused extra attributes and help with detecting errors.
 
 
 ### Save / Load

--- a/docs/pages/evolvers.md
+++ b/docs/pages/evolvers.md
@@ -1,7 +1,5 @@
 \page evolversdoc Evolvers
 
-\todo documen transforms
-
 Evolvers are the main component of HMC evolution.
 Their task is transforming one configuration into another one along the Markov chain.
 
@@ -45,6 +43,26 @@ As a good practice, all evolvers should use the `accept` and `reject` methods of
 `EvolutionStage` to clear out any unused extra attributes and help with detecting errors.
 
 
+### Transforms
+
+Some evolvers can be generalized by plugging arbitrary transformations between the proposal
+and accept/reject steps.
+Those transforms should inherit from isle.evolver.transform.transform.Transform.
+This way, they automatically tie in with the save/load mechanism described below.
+
+Transforms map between a proposal manifold and the actual Monte-carlo
+(MC) manifold.
+The latter is the manifold that the configurations produced by Isle live on.
+Measurements can be performed on those configurations.
+The former manifold is internal to the evolver and must be chosen such that that the
+configurations on the MC manifold have the correct distribution.
+Transforms must implement mappings in both direction.
+In Isle's parlance a 'forward' transform is from proposal to MC manifold.
+A 'backward' transform goes the other way around, from MC to proposal manifold.
+Note that all Jacobians must be specified with respect to forward transforms,
+even in the backward method!
+
+
 ### Save / Load
 
 Since evolvers drive HMC evolution, they can in some cases hold state which needs to be
@@ -56,10 +74,17 @@ In addition, information on the type of the evolver is stored in a separate loca
 This allows a run to be continued from just the HDF5 file without any need for
 additional, user written files.
 
+The same mechanisms that handle evolvers also write transforms to file and load them back in.
+In the case of evovlers, the HMC driver is responsible for saving and loading objects.
+Transforms on the other hand are regarded as details of the evolvers and must thus
+be stored and loaded by the evolvers themselves.
+See isle.evolver.leapfrog.ConstStepLeapfrog for an example how to do this.
+
+
 #### Saving Types
 
-Saving and loading the type of an evolver is handled by isle.evolver.EvolverManager and the
-individual evolvers do not have to do anything special to enable this
+Saving and loading the type of an evolver or transform is handled by isle.evolver.EvolverManager
+and the individual evolvers/transforms do not have to do anything special to enable this
 (except for the third point below).
 An exception to this are collective evolvers such as isle.evolver.Alternator which uses an
 evolver manager to save/load the types of its sub evolvers as part of its state.
@@ -67,55 +92,66 @@ This is necessary since the manager is unaware of the sub evolvers and cannot ha
 saving/loading the %Alternator type.
 
 isle.evolver.EvolverManager supports different ways of saving types in order to accommodate
-custom evolvers as well as built in ones.
-There are three scenarios for saving/loading evolver types
+custom classes as well as built in ones.
+There are three scenarios for saving/loading evolver and transform types
 (see \ref filelayout for more details on how this looks in the file):
-- The evolver is built into Isle (i.e. defined in package isle.evolver).
+- The evolver/transform is built into Isle (i.e. defined in packages isle.evolver,
+  isle.evolver.transform, respectively).
   In this case, reconstructing it is trivial and only its classname is stored in the file
   (dataset `__name__`).<br>
   Note to *developers*: All evolvers must be imported into the package isle.evolver
-  in order for `saveEvolverType` to find and store them correctly.
+  in order to be found and stored correctly.
 
-- The evolver is custom defined but is provided as part of the `definitions` argument
+- The evolver/transform is custom defined but is provided as part of the `definitions` argument
   to the constructor of EvolverManager.
-  Again, only the name of the class is stored and there is no visible difference
+  Again, only the name of the class is stored and there is no difference
   in the HDF5 file.<br>
-  The evolver can only be reconstructed if the type is provided to the EvolverManager
+  The instance can only be reconstructed if the type is provided to the EvolverManager
   which reads the file.
   This can potentially be in a different session and thus requires extra work and care by the user.
 
-- The evolver is custom defined and not provided to the manager.
-  In this case, the full source code of the evolver class is saved to the file in the dataset
-  `__source__` and `__name__` is set to `"__as_source__"`.
-  This allows custom evolvers to be reconstructed from file without any additional action by
+- The evolver/transform is custom defined and not provided to the manager.
+  In this case, the full source code of the evolver/transform class is saved to the file in
+  the dataset `__source__` and `__name__` is set to `"__as_source__"`.
+  This allows custom classes to be reconstructed from file without any additional action by
   the user.
-  This is used for instance by the program `isle continue`.
+  This is required by the program `isle continue`.
   \attention
-      Evolvers saved this way must be fully self contained, i.e. import
-      any required modules (modules `isle`, `evolvers`, and class `Evolver`
-      are provided and don't have to be imported).
+      Classes saved this way must be fully self contained, i.e. import
+      any required modules (modules `isle`, `evolver`, class `Evolver`, `transform`,
+      and class `Transform` are provided and don't have to be imported).
 
   &nbsp;
 
 
 #### Saving State
 
-Saving and loading state is the responsibility of the evolvers themselves.
-The `save` method is given an HDF5 group for the evolver to do with as it pleases.
-It must however ensure that calling `fromH5` with an HDF5 group constructs an evolver
+Saving and loading state is the responsibility of the evolvers and transforms themselves.
+The `save` method is given an HDF5 group for the evolver/transform to do with as it pleases.
+It must however ensure that calling `fromH5` with an HDF5 group constructs an instance
 that is completely equivalent to the one that was saved, i.e. any observable state must
 be the same.
 This is necessary to allow Isle to resume an HMC run.
+Any names with double underscores are reserved for internal use by Isle both
+in datasets and attributes.
 
-Evolvers are allowed to issue additional save/load commands through the EvolverManager
+Evolvers/transforms are allowed to issue additional save/load commands through the EvolverManager
 that is provided to `save` and `fromH5`.
-This can be used to save/load sub evolvers which would otherwise not be visible to
-the manager.
-See for example isle.evolver.Alternator.
+This can be used to save/load sub evolvers and must be used to save/load transforms
+which would otherwise not be visible to the manager.
+See for example isle.evolver.alternator.Alternator for sub evolvers and
+isle.evolver.leapfrog.ConstStepLeapfrog for transforms.
 
-`fromH5` has some additional parameters that contain some global parameters / state
+`fromH5` has some additional arguments that contain some global parameters / state
 of the simulation.
 Those are the action, lattice, and random number generator.
-The evolver is allowed to store references to them and use them for evolution.
-Since those objects are provided, they do not have to be saved by the evolver,
+The evolver/transform is allowed to store references to them and use them for evolution.
+Since those objects are provided by the driver, they do not have to be saved by the evolver,
 thus avoiding duplication and reducing file size.
+
+Note to *developers*: The HDF5 groups containing evolver and transform states have special attributes:
+- `__object_kind__`: Either `"Evolver"` or `"Transform"` to indicate whether this group holds state
+  of an evolver or transform.
+  EvolverManager chooses based on this attribute how to construct the object.
+- `__index__`: Integer index into the list of stored types for either evolvers or transforms.
+  This index refers to group `"/meta/evolvers"` to `"/meta/transforms"` in the same HDF5 file.

--- a/docs/pages/evolvers.md
+++ b/docs/pages/evolvers.md
@@ -4,8 +4,8 @@ Evolvers are the main component of HMC evolution.
 Their task is transforming one configuration into another one along the Markov chain.
 
 All evolvers must inherit from isle.evolver.Evolver and implement the abstract interface.
-- The <B>`evolve`</B> method takes an input configuration `phi` and conjugate momentum `pi`
-  and returns a new configuration and momentum.
+- The <B>`evolve`</B> method takes an input configuration `phi` and returns
+  a new configuration both stored in an instance of isle.evolver.stage.EvolutionStage.
 - <B>`save`</B> stores the current state of the evolver in an HDF5 group so the evolver can
   be reconstructed by `fromH5` later and resume evolution.
 - The classmethod <B>`fromH5`</B> constructs a new instance of the evolver from HDF5 based
@@ -19,13 +19,13 @@ They have to generate suitable proposals for new configurations and
 select one all in such a way that reversibility and detailed balance are maintained.
 Only the generation of the conjugate momenta is handled by the user.
 
-An examples of this is isle.evolver.ConstStepLeapfrog which uses leapfrog integration
+An examples of this is isle.evolver.leapfrog.ConstStepLeapfrog which uses leapfrog integration
 to generate a new `phi` and `pi` out of a starting configuration and momentum.
-Those new fields are either accepted or rejected by isle.evolver.BinarySelector which
+Those new fields are either accepted or rejected by isle.evolver.selector.BinarySelector which
 uses Metropolis accept/reject.
 
-Another example is isle.evolver.TwoPiJumps which generates discrete shifts in the
-configuration and uses knowledge of the action to compute the change in energy.
+Another example is isle.evolver.hubbard.TwoPiJumps which generates discrete shifts in the
+configuration and uses knowledge of the action of the Hubbard model to compute the change in energy.
 It can do multiple updates and accept or reject each one individually all encapsulated
 in one call to `evolve`.
 

--- a/src/isle/drivers/hmc.py
+++ b/src/isle/drivers/hmc.py
@@ -70,17 +70,16 @@ class HMC:
 
         for _ in _iterTrajectories(ntr):
             # get initial conditions for evolver
-            startPhi, startPi, startActVal = phi, Vector(self.rng.normal(0, 1, len(phi))+0j), actVal
+            startPhi, startActVal = phi, actVal
 
             try:
                 # get new fields
-                phi, _, actVal, trajPoint = evolver.evolve(startPhi, startPi, startActVal, trajPoint)
+                phi, actVal, trajPoint = evolver.evolve(startPhi, startActVal, trajPoint)
             except StopIteration:
                 # the evolver wants to stop,
                 # don't advance or save because no new config was produced
                 break
 
-            # TODO consistency checks
             # TODO inline meas
 
             # advance before saving because phi is a new configuration (no 0 is handled above)

--- a/src/isle/drivers/hmc.py
+++ b/src/isle/drivers/hmc.py
@@ -159,7 +159,7 @@ def newRun(lattice, params, rng, makeAction, outfile, overwrite, definitions={})
     \param overwrite If `False`, nothing in the output file will be erased/overwritten.
                      If `True`, the file is removed and re-initialized, whereby all content is lost.
     \param definitions Dictionary of mapping names to custom types. Used to control how evolvers
-                       are stored for checkpoints. See evolvers.saveEvolverType().
+                       are stored for checkpoints.
 
     \returns A new HMC instance to control evolution initialized with given parameters.
     """
@@ -195,7 +195,7 @@ def continueRun(infile, outfile, startIdx, overwrite, definitions={}):
                         - (`infile!=outfile`): outfile is removed and re-initialized,
                           whereby all content is lost.
     \param definitions Dictionary of mapping names to custom types. Used to control how evolvers
-                       are stored for checkpoints. See evolvers.saveEvolverType().
+                       are stored for checkpoints.
 
     \returns In order:
         - Instance of HMC constructed from parameters found in `infile`.

--- a/src/isle/drivers/hmc.py
+++ b/src/isle/drivers/hmc.py
@@ -74,7 +74,7 @@ class HMC:
 
             try:
                 # get new fields
-                phi, actVal, trajPoint = evolver.evolve(startPhi, startActVal, trajPoint)
+                phi, actVal, trajPoint, weights = evolver.evolve(startPhi, startActVal, trajPoint)
             except StopIteration:
                 # the evolver wants to stop,
                 # don't advance or save because no new config was produced

--- a/src/isle/evolver/__init__.py
+++ b/src/isle/evolver/__init__.py
@@ -10,8 +10,10 @@ from .alternator import Alternator  # (unused import) pylint: disable=W0611
 from .evolver import Evolver  # (unused import) pylint: disable=W0611
 from .leapfrog import ConstStepLeapfrog, LinearStepLeapfrog  # (unused import) pylint: disable=W0611
 from .hubbard import TwoPiJumps, UniformJump  # (unused import) pylint: disable=W0611
-from .autotuner import LeapfrogTuner
+from .autotuner import LeapfrogTuner  # (unused import) pylint: disable=W0611
 
 from .selector import BinarySelector  # (unused import) pylint: disable=W0611
 
 from .manager import EvolverManager, saveEvolverType, loadEvolverType  # (unused import) pylint: disable=W0611
+
+from . import transform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/__init__.py
+++ b/src/isle/evolver/__init__.py
@@ -11,10 +11,10 @@ from .evolver import Evolver  # (unused import) pylint: disable=W0611
 from .leapfrog import ConstStepLeapfrog, LinearStepLeapfrog  # (unused import) pylint: disable=W0611
 from .hubbard import TwoPiJumps, UniformJump  # (unused import) pylint: disable=W0611
 from .autotuner import LeapfrogTuner  # (unused import) pylint: disable=W0611
-from .stage import EvolutionStage
+from .stage import EvolutionStage  # (unused import) pylint: disable=W0611
 
 from .selector import BinarySelector  # (unused import) pylint: disable=W0611
 
-from .manager import EvolverManager, saveEvolverType, loadEvolverType  # (unused import) pylint: disable=W0611
+from .manager import EvolverManager  # (unused import) pylint: disable=W0611
 
 from . import transform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/__init__.py
+++ b/src/isle/evolver/__init__.py
@@ -11,6 +11,7 @@ from .evolver import Evolver  # (unused import) pylint: disable=W0611
 from .leapfrog import ConstStepLeapfrog, LinearStepLeapfrog  # (unused import) pylint: disable=W0611
 from .hubbard import TwoPiJumps, UniformJump  # (unused import) pylint: disable=W0611
 from .autotuner import LeapfrogTuner  # (unused import) pylint: disable=W0611
+from .stage import EvolutionStage
 
 from .selector import BinarySelector  # (unused import) pylint: disable=W0611
 

--- a/src/isle/evolver/alternator.py
+++ b/src/isle/evolver/alternator.py
@@ -87,6 +87,8 @@ class Alternator(Evolver):
           - New configuration
           - Action evaluated on new configuration
           - Point along trajectory that was selected
+          - Weights for re-weighting for new configuration, not including the action.
+            `dict` or `None`.
         """
 
         subEvolver = self._pickCurrentEvolver()

--- a/src/isle/evolver/alternator.py
+++ b/src/isle/evolver/alternator.py
@@ -77,24 +77,17 @@ class Alternator(Evolver):
                 return evolver
         return None
 
-    def evolve(self, phi, actVal, trajPoint):
+    def evolve(self, stage):
         r"""!
         Delegate to a sub evolver next in line.
-        \param phi Input configuration.
-        \param actVal Value of the action at phi.
-        \param trajPoint 0 if previous trajectory was rejected, 1 if it was accepted.
-        \returns In order:
-          - New configuration
-          - Action evaluated on new configuration
-          - Point along trajectory that was selected
-          - Weights for re-weighting for new configuration, not including the action.
-            `dict` or `None`.
+        \param stage EvolutionStage at the beginning of this evolution step.
+        \returns EvolutionStage at the end of this evolution step.
         """
 
         subEvolver = self._pickCurrentEvolver()
         self._advance()
 
-        return subEvolver.evolve(phi, actVal, trajPoint)
+        return subEvolver.evolve(stage)
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/alternator.py
+++ b/src/isle/evolver/alternator.py
@@ -77,16 +77,14 @@ class Alternator(Evolver):
                 return evolver
         return None
 
-    def evolve(self, phi, pi, actVal, trajPoint):
+    def evolve(self, phi, actVal, trajPoint):
         r"""!
         Delegate to a sub evolver next in line.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param trajPoint 0 if previous trajectory was rejected, 1 if it was accepted.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated on new configuration
           - Point along trajectory that was selected
         """
@@ -94,7 +92,7 @@ class Alternator(Evolver):
         subEvolver = self._pickCurrentEvolver()
         self._advance()
 
-        return subEvolver.evolve(phi, pi, actVal, trajPoint)
+        return subEvolver.evolve(phi, actVal, trajPoint)
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/autotuner.py
+++ b/src/isle/evolver/autotuner.py
@@ -678,13 +678,15 @@ class LeapfrogTuner(Evolver):  # pylint: disable=too-many-instance-attributes
           - New configuration
           - Action evaluated at new configuration
           - Point along trajectory that was selected
+          - Weights for re-weighting for new configuration, not including the action.
+            `dict` or `None`.
         """
 
         # do not evolve any more, signal the driver to stop
         if self._finished:
             raise StopIteration()
 
-        phi, actVal, trajPoint = self._doEvolve(phi, actVal, trajPoint)
+        phi, actVal, trajPoint, weights = self._doEvolve(phi, actVal, trajPoint)
 
         log = getLogger("atune")
         currentRecord = self.registrar.currentRecord()
@@ -713,7 +715,7 @@ class LeapfrogTuner(Evolver):  # pylint: disable=too-many-instance-attributes
             log.error("Tuning was unsuccessful within the given maximum number of runs")
             self._finalize(None)
 
-        return phi, actVal, trajPoint
+        return phi, actVal, trajPoint, weights
 
     def currentParams(self):
         r"""!
@@ -737,8 +739,8 @@ class LeapfrogTuner(Evolver):  # pylint: disable=too-many-instance-attributes
         self.registrar.currentRecord().add(min(1, exp(np.real(energy0 - energy1))),
                                            trajPoint1)
 
-        return (phi1, actVal1, trajPoint1) if trajPoint1 == 1 \
-            else (phi0, actVal0, trajPoint1)
+        return (phi1, actVal1, trajPoint1, None) if trajPoint1 == 1 \
+            else (phi0, actVal0, trajPoint1, None)
 
     def _shiftNstep(self):
         r"""!

--- a/src/isle/evolver/autotuner.py
+++ b/src/isle/evolver/autotuner.py
@@ -668,16 +668,14 @@ class LeapfrogTuner(Evolver):  # pylint: disable=too-many-instance-attributes
         ## Final tuned parameters, None if incomplete or unsuccessful.
         self._tunedParameters = None
 
-    def evolve(self, phi, pi, actVal, trajPoint):
+    def evolve(self, phi, actVal, trajPoint):
         r"""!
         Run one step of leapfrog integration and tune parameters.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param trajPoint 0 if previous trajectory was rejected, 1 if it was accepted.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - Point along trajectory that was selected
         """
@@ -715,7 +713,7 @@ class LeapfrogTuner(Evolver):  # pylint: disable=too-many-instance-attributes
             log.error("Tuning was unsuccessful within the given maximum number of runs")
             self._finalize(None)
 
-        return phi, pi, actVal, trajPoint
+        return phi, actVal, trajPoint
 
     def currentParams(self):
         r"""!

--- a/src/isle/evolver/evolver.py
+++ b/src/isle/evolver/evolver.py
@@ -12,18 +12,11 @@ class Evolver(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def evolve(self, phi, actVal, trajPoint):
+    def evolve(self, stage):
         r"""!
         Evolve a configuration and momentum.
-        \param phi Input configuration.
-        \param actVal Value of the action at phi.
-        \param trajPoint 0 if previous trajectory was rejected, 1 if it was accepted.
-        \returns In order:
-          - New configuration
-          - Action evaluated at new configuration
-          - Point along trajectory that was selected
-          - Weights for re-weighting for new configuration, not including the action.
-            `dict` or `None`.
+        \param stage EvolutionStage at the beginning of this evolution step.
+        \returns EvolutionStage at the end of this evolution step.
         """
 
     @abstractmethod

--- a/src/isle/evolver/evolver.py
+++ b/src/isle/evolver/evolver.py
@@ -12,16 +12,14 @@ class Evolver(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def evolve(self, phi, pi, actVal, trajPoint):
+    def evolve(self, phi, actVal, trajPoint):
         r"""!
         Evolve a configuration and momentum.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param trajPoint 0 if previous trajectory was rejected, 1 if it was accepted.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - Point along trajectory that was selected
         """

--- a/src/isle/evolver/evolver.py
+++ b/src/isle/evolver/evolver.py
@@ -22,6 +22,8 @@ class Evolver(metaclass=ABCMeta):
           - New configuration
           - Action evaluated at new configuration
           - Point along trajectory that was selected
+          - Weights for re-weighting for new configuration, not including the action.
+            `dict` or `None`.
         """
 
     @abstractmethod

--- a/src/isle/evolver/hubbard.py
+++ b/src/isle/evolver/hubbard.py
@@ -44,16 +44,14 @@ class TwoPiJumps(Evolver):
 
         self._action = _HubbardActionShortcut(action)
 
-    def evolve(self, phi, pi, actVal, trajPoint):
+    def evolve(self, phi, actVal, trajPoint):
         r"""!
         Evolve a configuration, momentum remains unchanged.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param trajPoint \e ignored.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
         """
@@ -79,7 +77,7 @@ class TwoPiJumps(Evolver):
             # else:
             #     nothing to do, variables are already set up
 
-        return phi, pi, actVal, trajPoint
+        return phi, actVal, trajPoint
 
     def save(self, h5group, _manager):
         r"""!
@@ -129,16 +127,14 @@ class UniformJump(Evolver):
         # absolute value of shift
         self._absShift = 2*np.pi/lattice.nt()
 
-    def evolve(self, phi, pi, actVal, trajPoint):
+    def evolve(self, phi, actVal, trajPoint):
         r"""!
         Evolve a configuration, momentum remains unchanged.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param trajPoint \e ignored.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
         """
@@ -153,7 +149,7 @@ class UniformJump(Evolver):
         else:
             trajPoint = 0
 
-        return phi, pi, actVal, trajPoint
+        return phi, actVal, trajPoint
 
     def save(self, _h5group, _manager):
         r"""!

--- a/src/isle/evolver/hubbard.py
+++ b/src/isle/evolver/hubbard.py
@@ -54,6 +54,8 @@ class TwoPiJumps(Evolver):
           - New configuration
           - Action evaluated at new configuration
           - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
+          - `None` (Weights for re-weighting for new configuration, not including the action.
+            No special weights here)
         """
 
         # nothing accepted yet
@@ -77,7 +79,7 @@ class TwoPiJumps(Evolver):
             # else:
             #     nothing to do, variables are already set up
 
-        return phi, actVal, trajPoint
+        return phi, actVal, trajPoint, None
 
     def save(self, h5group, _manager):
         r"""!
@@ -137,6 +139,8 @@ class UniformJump(Evolver):
           - New configuration
           - Action evaluated at new configuration
           - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
+          - `None` (Weights for re-weighting for new configuration, not including the action.
+            No special weights here)
         """
 
         shift = self.rng.choice((-1, +1)) * self._absShift
@@ -149,7 +153,7 @@ class UniformJump(Evolver):
         else:
             trajPoint = 0
 
-        return phi, actVal, trajPoint
+        return phi, actVal, trajPoint, None
 
     def save(self, _h5group, _manager):
         r"""!

--- a/src/isle/evolver/hubbard.py
+++ b/src/isle/evolver/hubbard.py
@@ -44,18 +44,11 @@ class TwoPiJumps(Evolver):
 
         self._action = _HubbardActionShortcut(action)
 
-    def evolve(self, phi, actVal, trajPoint):
+    def evolve(self, stage):
         r"""!
         Evolve a configuration, momentum remains unchanged.
-        \param phi Input configuration.
-        \param actVal Value of the action at phi.
-        \param trajPoint \e ignored.
-        \returns In order:
-          - New configuration
-          - Action evaluated at new configuration
-          - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
-          - `None` (Weights for re-weighting for new configuration, not including the action.
-            No special weights here)
+        \param stage EvolutionStage at the beginning of this evolution step.
+        \returns EvolutionStage at the end of this evolution step.
         """
 
         # nothing accepted yet
@@ -68,18 +61,14 @@ class TwoPiJumps(Evolver):
             shifts = self.rng.choice((-2*np.pi, +2*np.pi), self.batchSize, replace=True)
 
             # perform jumps
-            newPhi = np.array(phi, copy=True)
+            newPhi = np.array(stage.phi, copy=True)
             newPhi[sites] += shifts
-            newActVal = self._action.evalLocal(newPhi, sites, shifts, actVal)
+            newActVal = self._action.evalLocal(newPhi, sites, shifts, stage.actVal)
 
             # no need to put pi into check, it never changes in here
-            if self.selector.selectTrajPoint(actVal, newActVal) == 1:
-                phi, actVal = newPhi, newActVal
-                trajPoint = 1  # something has been accepted
-            # else:
-            #     nothing to do, variables are already set up
-
-        return phi, actVal, trajPoint, None
+            if self.selector.selectTrajPoint(stage.actVal, newActVal) == 1:
+                return stage.accept(isle.Vector(newPhi), newActVal)
+            return stage.reject()
 
     def save(self, h5group, _manager):
         r"""!
@@ -129,31 +118,20 @@ class UniformJump(Evolver):
         # absolute value of shift
         self._absShift = 2*np.pi/lattice.nt()
 
-    def evolve(self, phi, actVal, trajPoint):
+    def evolve(self, stage):
         r"""!
         Evolve a configuration, momentum remains unchanged.
-        \param phi Input configuration.
-        \param actVal Value of the action at phi.
-        \param trajPoint \e ignored.
-        \returns In order:
-          - New configuration
-          - Action evaluated at new configuration
-          - 0 if no jump was accepted, 1 if at least one was accepted (across all batches).
-          - `None` (Weights for re-weighting for new configuration, not including the action.
-            No special weights here)
+        \param stage EvolutionStage at the beginning of this evolution step.
+        \returns EvolutionStage at the end of this evolution step.
         """
 
         shift = self.rng.choice((-1, +1)) * self._absShift
-        newPhi = np.array(phi, copy=False) + shift
-        newActVal = self._action.evalGlobal(newPhi, shift, actVal)
+        newPhi = np.array(stage.phi, copy=False) + shift
+        newActVal = self._action.evalGlobal(newPhi, shift, stage.actVal)
 
-        if self.selector.selectTrajPoint(actVal, newActVal) == 1:
-            phi, actVal = isle.Vector(newPhi), newActVal
-            trajPoint = 1
-        else:
-            trajPoint = 0
-
-        return phi, actVal, trajPoint, None
+        if self.selector.selectTrajPoint(stage.actVal, newActVal) == 1:
+            return stage.accept(isle.Vector(newPhi), newActVal)
+        return stage.reject()
 
     def save(self, _h5group, _manager):
         r"""!

--- a/src/isle/evolver/leapfrog.py
+++ b/src/isle/evolver/leapfrog.py
@@ -29,16 +29,14 @@ class ConstStepLeapfrog(Evolver):
         self.rng = rng
         self.selector = BinarySelector(rng)
 
-    def evolve(self, phi, pi, actVal, _trajPoint):
+    def evolve(self, phi, actVal, _trajPoint):
         r"""!
         Run leapfrog integrator.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param _trajPoint \e ignored.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - Point along trajectory that was selected
         """
@@ -47,8 +45,8 @@ class ConstStepLeapfrog(Evolver):
         phi1, pi1, actVal1 = leapfrog(phi, pi, self.action, self.length, self.nstep)
         trajPoint = self.selector.selectTrajPoint(actVal+np.linalg.norm(pi)**2/2,
                                                   actVal1+np.linalg.norm(pi1)**2/2)
-        return (phi1, pi1, actVal1, trajPoint) if trajPoint == 1 \
-            else (phi, pi, actVal, trajPoint)
+        return (phi1, actVal1, trajPoint) if trajPoint == 1 \
+            else (phi, actVal, trajPoint)
 
     def save(self, h5group, manager):
         r"""!
@@ -113,16 +111,14 @@ class LinearStepLeapfrog(Evolver):
             next(self._lengthIter)
             next(self._nstepIter)
 
-    def evolve(self, phi, pi, actVal, _trajPoint):
+    def evolve(self, phi, actVal, _trajPoint):
         r"""!
         Run leapfrog integrator.
         \param phi Input configuration.
-        \param pi Input Momentum.
         \param actVal Value of the action at phi.
         \param _trajPoint \e ignored.
         \returns In order:
           - New configuration
-          - New momentum
           - Action evaluated at new configuration
           - Point along trajectory that was selected
         """
@@ -133,8 +129,8 @@ class LinearStepLeapfrog(Evolver):
                                       next(self._lengthIter), int(next(self._nstepIter)))
         trajPoint = self.selector.selectTrajPoint(actVal+np.linalg.norm(pi)**2/2,
                                                   actVal1+np.linalg.norm(pi1)**2/2)
-        return (phi1, pi1, actVal1, trajPoint) if trajPoint == 1 \
-            else (phi, pi, actVal, trajPoint)
+        return (phi1, actVal1, trajPoint) if trajPoint == 1 \
+            else (phi, actVal, trajPoint)
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/leapfrog.py
+++ b/src/isle/evolver/leapfrog.py
@@ -6,7 +6,7 @@ Evolvers that perform molecular dynamics integration of configurations using lea
 import numpy as np
 
 from .evolver import Evolver
-from .transform import backwardTransform
+from .transform import backwardTransform, forwardTransform
 from .selector import BinarySelector
 from .. import Vector, leapfrog
 from ..collection import hingeRange
@@ -49,8 +49,7 @@ class ConstStepLeapfrog(Evolver):
         phiMD1, pi1, actValMD1 = leapfrog(phiMD, pi, self.action, self.length, self.nstep)
 
         # transform to MC manifold
-        (phi1, actVal1, logdetJ1) = (phiMD1, actValMD1, 0) if self.transform is None \
-            else self.transform.forward(phiMD1, actValMD1)
+        phi1, actVal1, logdetJ1 = forwardTransform(self.transform, phiMD1, actValMD1)
 
         # accept/reject on MC manifold
         trajPoint = self.selector.selectTrajPoint(stage.sumLogWeights()+np.linalg.norm(pi)**2/2,
@@ -152,8 +151,7 @@ class LinearStepLeapfrog(Evolver):
                                           next(self._lengthIter), int(next(self._nstepIter)))
 
         # transform to MC manifold
-        (phi1, actVal1, logdetJ1) = (phiMD1, actValMD1, 0) if self.transform is None \
-            else self.transform.forward(phiMD1, actValMD1)
+        phi1, actVal1, logdetJ1 = forwardTransform(self.transform, phiMD1, actValMD1)
 
         # accept/reject on MC manifold
         trajPoint = self.selector.selectTrajPoint(stage.sumLogWeights()+np.linalg.norm(pi)**2/2,

--- a/src/isle/evolver/leapfrog.py
+++ b/src/isle/evolver/leapfrog.py
@@ -68,23 +68,21 @@ class ConstStepLeapfrog(Evolver):
         h5group["length"] = self.length
         h5group["nstep"] = self.nstep
         if self.transform is not None:
-            # TODO dispatch to the manager as well
-            self.transform.save(h5group.create_group("transform"), manager)
+            manager.save(self.transform, h5group.create_group("transform"))
 
     @classmethod
-    def fromH5(cls, h5group, _manager, action, _lattice, rng):
+    def fromH5(cls, h5group, manager, action, lattice, rng):
         r"""!
         Construct from HDF5.
         \param h5group HDF5 group to load parameters from.
-        \param _manager \e ignored.
+        \param manager EvolverManager responsible for the HDF5 file.
         \param action Action to use.
-        \param _lattice \e ignored.
+        \param lattice Lattice the simulation runs on.
         \param rng Central random number generator for the run.
-        \returns A newly constructed leapfrog evolver.
+        \returns A newly constructed evolver.
         """
         if "transform" in h5group:
-            # TODO get type from manager
-            transform = None
+            transform = manager.load(h5group[f"transform"], action, lattice, rng)
         else:
             transform = None
         return cls(action, h5group["length"][()], h5group["nstep"][()], rng, transform)
@@ -174,23 +172,21 @@ class LinearStepLeapfrog(Evolver):
         h5group["ninterp"] = self.ninterp
         h5group["current"] = self._current
         if self.transform is not None:
-            # TODO dispatch to the manager as well
-            self.transform.save(h5group.create_group("transform"), manager)
+            manager.save(self.transform, h5group.create_group("transform"))
 
     @classmethod
-    def fromH5(cls, h5group, _manager, action, _lattice, rng):
+    def fromH5(cls, h5group, manager, action, lattice, rng):
         r"""!
         Construct from HDF5.
         \param h5group HDF5 group to load parameters from.
-        \param _manager \e ignored.
+        \param manager EvolverManager responsible for the HDF5 file.
         \param action Action to use.
-        \param _lattice \e ignored.
+        \param lattice Lattice the simulation runs on.
         \param rng Central random number generator for the run.
-        \returns A newly constructed leapfrog evolver.
+        \returns A newly constructed evolver.
         """
         if "transform" in h5group:
-            # TODO get type from manager
-            transform = None
+            transform = manager.load(h5group[f"transform"], action, lattice, rng)
         else:
             transform = None
         return cls(action,
@@ -198,4 +194,5 @@ class LinearStepLeapfrog(Evolver):
                    (h5group["minNstep"][()], h5group["maxNstep"][()]),
                    h5group["ninterp"][()],
                    rng,
-                   h5group["current"][()])
+                   startPoint=h5group["current"][()],
+                   transform=transform)

--- a/src/isle/evolver/leapfrog.py
+++ b/src/isle/evolver/leapfrog.py
@@ -39,14 +39,16 @@ class ConstStepLeapfrog(Evolver):
           - New configuration
           - Action evaluated at new configuration
           - Point along trajectory that was selected
+          - Weights for re-weighting for new configuration, not including the action.
+            `dict` or `None`.
         """
 
         pi = Vector(self.rng.normal(0, 1, len(phi))+0j)
         phi1, pi1, actVal1 = leapfrog(phi, pi, self.action, self.length, self.nstep)
         trajPoint = self.selector.selectTrajPoint(actVal+np.linalg.norm(pi)**2/2,
                                                   actVal1+np.linalg.norm(pi1)**2/2)
-        return (phi1, actVal1, trajPoint) if trajPoint == 1 \
-            else (phi, actVal, trajPoint)
+        return (phi1, actVal1, trajPoint, None) if trajPoint == 1 \
+            else (phi, actVal, trajPoint, None)
 
     def save(self, h5group, manager):
         r"""!
@@ -121,6 +123,8 @@ class LinearStepLeapfrog(Evolver):
           - New configuration
           - Action evaluated at new configuration
           - Point along trajectory that was selected
+          - Weights for re-weighting for new configuration, not including the action.
+            `dict` or `None`.
         """
         self._current += 1
 
@@ -129,8 +133,8 @@ class LinearStepLeapfrog(Evolver):
                                       next(self._lengthIter), int(next(self._nstepIter)))
         trajPoint = self.selector.selectTrajPoint(actVal+np.linalg.norm(pi)**2/2,
                                                   actVal1+np.linalg.norm(pi1)**2/2)
-        return (phi1, actVal1, trajPoint) if trajPoint == 1 \
-            else (phi, actVal, trajPoint)
+        return (phi1, actVal1, trajPoint, None) if trajPoint == 1 \
+            else (phi, actVal, trajPoint, None)
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/stage.py
+++ b/src/isle/evolver/stage.py
@@ -1,0 +1,105 @@
+r"""!\file
+\ingroup evolvers
+Store a state of MCMC evolution.
+"""
+
+
+from isle import Vector
+
+
+class EvolutionStage:
+    """!
+    Hold the status of MCMC at some point in the evolution.
+
+    Stores the configuration and corresponding weight.
+    `exp(-real(stage.sumLogWeights()))` is the weight used for accept/reject
+    and the correspondint imagianry part is used for re-weighting.
+    Not the minus sign!
+    """
+
+    __slots__ = "phi", "trajPoint", "logWeights", "extra"
+
+    def __init__(self, phi, actVal, trajPoint=1, logWeights=None, extra=None):
+        """!
+        Store parameters.
+        """
+        ## Configuration.
+        self.phi = phi
+        ## Selected trajectory point.
+        self.trajPoint = trajPoint
+        ## dict(str -> complex) of log of all weights, always contains key "actVal".
+        self.logWeights = logWeights if logWeights is not None else dict()
+        self.logWeights["actVal"] = actVal
+        ## dict(str -> object) of extra data.
+        self.extra = extra if extra is not None else dict()
+
+    @property
+    def actVal(self):
+        """!
+        Value of the action at phi (complex).
+        """
+        return self.logWeights["actVal"]
+
+    @actVal.setter
+    def actVal(self, actVal):
+        self.logWeights["actVal"] = actVal
+
+    def nonActWeigths(self):
+        """!
+        Iterator over key, value pairs of all log weights other than the action.
+        """
+        yield from filter(lambda item: item[0] != "actVal",
+                          self.logWeights.items())
+
+    def accept(self, phi, actVal, logWeights=None, extra=None):
+        """!
+        Return a new EvolutionStage which indicates acceptance with given parameters.
+        """
+        return self.__class__(phi, actVal, 1, logWeights, extra)
+
+    def reject(self, logWeights=None, extra=None):
+        """!
+        Return a new EvolutionStage which indicates rejection and reuses phi and actVal.
+        `logWeights` and `extra` are always overwritten.
+        """
+        return self.__class__(self.phi, self.actVal, 0, logWeights, extra)
+
+    def sumLogWeights(self):
+        """!
+        Return the sum of all log weights.
+        """
+        return sum(self.logWeights.values())
+
+    def save(self, h5group):
+        """!
+        Save contents to an HDF5 group.
+        """
+        h5group["phi"] = self.phi
+        h5group["action"] = self.actVal
+        h5group["trajPoint"] = self.trajPoint
+
+        # write additional weights is there are any
+        if len(self.logWeights) > 1:
+            wgrp = h5group.create_group("logWeights")
+            for key, val in self.nonActWeigths():
+                wgrp[key] = val
+
+        if self.extra:
+            egrp = h5group.create_group("extra")
+            for key, val in self.extra():
+                egrp[key] = val
+
+    @classmethod
+    def fromH5(cls, h5group):
+        """!
+        Construct a new instance from an HDF5 group written by EvolutionStage.save().
+        """
+        extra = {key: dset[()] for key, dset in h5group["extra"].items()} \
+            if "extra" in h5group else None
+        logWeights = {key: dset[()] for key, dset in h5group["logWeights"].items()} \
+            if "logWeights" in h5group else None
+        return cls(Vector(h5group["phi"][()]),
+                   h5group["action"][()],
+                   h5group["trajPoint"][()],
+                   logWeights,
+                   extra)

--- a/src/isle/evolver/stage.py
+++ b/src/isle/evolver/stage.py
@@ -16,6 +16,7 @@ class EvolutionStage:
     and the correspondint imagianry part is used for re-weighting.
     Not the minus sign!
     """
+    # TODO is the minus correct?
 
     __slots__ = "phi", "trajPoint", "logWeights", "extra"
 
@@ -57,12 +58,12 @@ class EvolutionStage:
         """
         return self.__class__(phi, actVal, 1, logWeights, extra)
 
-    def reject(self, logWeights=None, extra=None):
+    def reject(self, extra=None):
         """!
         Return a new EvolutionStage which indicates rejection and reuses phi and actVal.
         `logWeights` and `extra` are always overwritten.
         """
-        return self.__class__(self.phi, self.actVal, 0, logWeights, extra)
+        return self.__class__(self.phi, self.actVal, 0, self.logWeights, extra)
 
     def sumLogWeights(self):
         """!

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -4,4 +4,4 @@ Transformations of configurations during MC evolution.
 """
 
 from .identity import Identity  # (unused import) pylint: disable=W0611
-from .transform import Transform  # (unused import) pylint: disable=W0611
+from .transform import Transform, backwardTransform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -3,4 +3,5 @@ r"""!\file
 Transformations of configurations during MC evolution.
 """
 
+from .identity import Identity  # (unused import) pylint: disable=W0611
 from .transform import Transform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -1,4 +1,4 @@
-r"""!\file
+r"""!
 \ingroup evolvers
 Transformations of configurations during MC evolution.
 """

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -3,5 +3,6 @@ r"""!\file
 Transformations of configurations during MC evolution.
 """
 
+from .constantShift import ConstantShift  # (unused import) pylint: disable=W0611
 from .identity import Identity  # (unused import) pylint: disable=W0611
 from .transform import Transform, backwardTransform, forwardTransform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -1,0 +1,6 @@
+r"""!\file
+\ingroup evolvers
+Transformations of configurations during MC evolution.
+"""
+
+from .transform import Transform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/transform/__init__.py
+++ b/src/isle/evolver/transform/__init__.py
@@ -4,4 +4,4 @@ Transformations of configurations during MC evolution.
 """
 
 from .identity import Identity  # (unused import) pylint: disable=W0611
-from .transform import Transform, backwardTransform  # (unused import) pylint: disable=W0611
+from .transform import Transform, backwardTransform, forwardTransform  # (unused import) pylint: disable=W0611

--- a/src/isle/evolver/transform/constantShift.py
+++ b/src/isle/evolver/transform/constantShift.py
@@ -27,7 +27,7 @@ class ConstantShift(Transform):
 
     def forward(self, phi, actVal):
         r"""!
-        Transform a configuration from proposal to MC manifold.
+        Shift by +shift.
         \param phi Configuration on proposal manifold.
         \param actVal Value of the action at phi.
         \returns In order:
@@ -39,7 +39,7 @@ class ConstantShift(Transform):
 
     def backward(self, phi, jacobian=False):
         r"""!
-        Transform a configuration from MC to proposal manifold.
+        Shift by -shift.
         \param phi Configuration on MC manifold.
         \returns
             - Configuration on proposal manifold
@@ -60,7 +60,7 @@ class ConstantShift(Transform):
     @classmethod
     def fromH5(cls, h5group, _manager, action, _lattice, _rng):
         r"""!
-        Construct a trasnform from HDF5.
+        Construct a transform from HDF5.
         Create and initialize a new instance from parameters stored via Identity.save().
         \param h5group HDF5 group to load parameters from.
         \param _manager EvolverManager responsible for the HDF5 file.

--- a/src/isle/evolver/transform/constantShift.py
+++ b/src/isle/evolver/transform/constantShift.py
@@ -1,0 +1,72 @@
+r"""!\file
+\ingroup evolvers
+Transform to shift configurations by a constant.
+"""
+
+
+import numpy as np
+
+from .transform import Transform
+from ... import CDVector
+
+
+class ConstantShift(Transform):
+    r"""! \ingroup evolvers
+    Transform that shifts configurations by a constant.
+    """
+
+    def __init__(self, shift, action, lattSize=None):
+        if isinstance(shift, (np.ndarray, CDVector)):
+            self.shift = CDVector(shift)
+        else:
+            if lattSize is None:
+                raise ValueError("Argument lattSize must not be None if shift is"
+                                 " passed as a scalar")
+            self.shift = CDVector(np.full(lattSize, shift, dtype=complex))
+        self.action = action
+
+    def forward(self, phi, actVal):
+        r"""!
+        Transform a configuration from proposal to MC manifold.
+        \param phi Configuration on proposal manifold.
+        \param actVal Value of the action at phi.
+        \returns In order:
+          - Configuration on MC manifold.
+          - Value of action at configuration on MC manifold.
+          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the transformation.
+        """
+        return phi+self.shift, self.action.eval(phi), 0
+
+    def backward(self, phi, jacobian=False):
+        r"""!
+        Transform a configuration from MC to proposal manifold.
+        \param phi Configuration on MC manifold.
+        \returns
+            - Configuration on proposal manifold
+            - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the
+              *forwards* transformation. `None` if `jacobian==False`.
+        """
+        return phi-self.shift, 0 if jacobian else None
+
+    def save(self, h5group, manager):
+        r"""!
+        Save the transform to HDF5.
+        Has to be the inverse of Transform.fromH5().
+        \param h5group HDF5 group to save to.
+        \param manager EvolverManager whose purview to save the transform in.
+        """
+        h5group["shift"] = self.shift
+
+    @classmethod
+    def fromH5(cls, h5group, _manager, action, _lattice, _rng):
+        r"""!
+        Construct a trasnform from HDF5.
+        Create and initialize a new instance from parameters stored via Identity.save().
+        \param h5group HDF5 group to load parameters from.
+        \param _manager EvolverManager responsible for the HDF5 file.
+        \param action Action to use.
+        \param _lattice Lattice the simulation runs on.
+        \param _rng Central random number generator for the run.
+        \returns A newly constructed identity transform.
+        """
+        return cls(h5group["shift"][()], action)

--- a/src/isle/evolver/transform/identity.py
+++ b/src/isle/evolver/transform/identity.py
@@ -1,0 +1,58 @@
+r"""!\file
+\ingroup evolvers
+Identity transform.
+"""
+
+
+from .transform import Transform
+
+
+class Identity(Transform):
+    r"""! \ingroup evolvers
+    Identity transform that returns the input configuration unchanged.
+    """
+
+    def forward(self, phi, actVal):
+        r"""!
+        Transform a configuration from proposal to MC manifold.
+        \param phi Configuration on proposal manifold.
+        \param actVal Value of the action at phi.
+        \returns In order:
+          - Configuration on MC manifold.
+          - Value of action at configuration on MC manifold.
+          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the transformation.
+        """
+        return phi, actVal, 0
+
+    def backward(self, phi):
+        r"""!
+        Transform a configuration from MC to proposal manifold.
+        \param phi Configuration on MC manifold.
+        \returns In order:
+          - Configuration on proposal manifold.
+          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the *forward* transformation.
+        """
+        return phi, 0
+
+    def save(self, h5group, manager):
+        r"""!
+        Save the transform to HDF5.
+        Has to be the inverse of Transform.fromH5().
+        \param h5group HDF5 group to save to.
+        \param manager EvolverManager whose purview to save the transform in.
+        """
+        # nothing to save
+
+    @classmethod
+    def fromH5(cls, _h5group, _manager, _action, _lattice, _rng):
+        r"""!
+        Construct a trasnform from HDF5.
+        Create and initialize a new instance from parameters stored via Identity.save().
+        \param _h5group HDF5 group to load parameters from.
+        \param _manager EvolverManager responsible for the HDF5 file.
+        \param _action Action to use.
+        \param _lattice Lattice the simulation runs on.
+        \param _rng Central random number generator for the run.
+        \returns A newly constructed identity transform.
+        """
+        return cls()

--- a/src/isle/evolver/transform/identity.py
+++ b/src/isle/evolver/transform/identity.py
@@ -28,11 +28,9 @@ class Identity(Transform):
         r"""!
         Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
-        \returns In order:
-          - Configuration on proposal manifold.
-          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the *forward* transformation.
+        \returns Configuration on proposal manifold.
         """
-        return phi, 0
+        return phi
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/transform/identity.py
+++ b/src/isle/evolver/transform/identity.py
@@ -14,7 +14,7 @@ class Identity(Transform):
 
     def forward(self, phi, actVal):
         r"""!
-        Transform a configuration from proposal to MC manifold.
+        %Transform a configuration from proposal to MC manifold.
         \param phi Configuration on proposal manifold.
         \param actVal Value of the action at phi.
         \returns In order:
@@ -26,7 +26,7 @@ class Identity(Transform):
 
     def backward(self, phi, jacobian=False):
         r"""!
-        Transform a configuration from MC to proposal manifold.
+        %Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
         \returns
             - Configuration on proposal manifold
@@ -47,7 +47,7 @@ class Identity(Transform):
     @classmethod
     def fromH5(cls, _h5group, _manager, _action, _lattice, _rng):
         r"""!
-        Construct a trasnform from HDF5.
+        Construct a transform from HDF5.
         Create and initialize a new instance from parameters stored via Identity.save().
         \param _h5group HDF5 group to load parameters from.
         \param _manager EvolverManager responsible for the HDF5 file.

--- a/src/isle/evolver/transform/identity.py
+++ b/src/isle/evolver/transform/identity.py
@@ -24,13 +24,16 @@ class Identity(Transform):
         """
         return phi, actVal, 0
 
-    def backward(self, phi):
+    def backward(self, phi, jacobian=False):
         r"""!
         Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
-        \returns Configuration on proposal manifold.
+        \returns
+            - Configuration on proposal manifold
+            - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the
+              *forwards* transformation. `None` if `jacobian==False`.
         """
-        return phi
+        return phi, 0 if jacobian else None
 
     def save(self, h5group, manager):
         r"""!

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -12,13 +12,14 @@ class Transform(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def forward(self, phi):
+    def forward(self, phi, actVal):
         r"""!
         Transform a configuration from proposal to MC manifold.
         \param phi Configuration on proposal manifold.
+        \param actVal Value of the action at phi.
         \returns In order:
           - Configuration on MC manifold.
-          - Value of action at new configuration.
+          - Value of action at configuration on MC manifold.
           - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the transformation.
         """
 

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -1,0 +1,56 @@
+r"""!\file
+\ingroup evolvers
+Base class for evolvers.
+"""
+
+from abc import ABCMeta, abstractmethod
+
+
+class Transform(metaclass=ABCMeta):
+    r"""! \ingroup evolvers
+    Abstract base class for evolver transforms.
+    """
+
+    @abstractmethod
+    def forward(self, phi):
+        r"""!
+        Transform a configuration from proposal to MC manifold.
+        \param phi Configuration on proposal manifold.
+        \returns In order:
+          - Configuration on MC manifold.
+          - Value of action at new configuration.
+          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the transformation.
+        """
+
+    @abstractmethod
+    def backward(self, phi):
+        r"""!
+        Transform a configuration from MC to proposal manifold.
+        \param phi Configuration on MC manifold.
+        \returns In order:
+          - Configuration on proposal manifold.
+          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the *forward* transformation.
+        """
+
+    @abstractmethod
+    def save(self, h5group, manager):
+        r"""!
+        Save the transform to HDF5.
+        Has to be the inverse of Transform.fromH5().
+        \param h5group HDF5 group to save to.
+        \param manager EvolverManager whose purview to save the transform in.
+        """
+
+    @classmethod
+    @abstractmethod
+    def fromH5(cls, h5group, manager, action, lattice, rng):
+        r"""!
+        Construct a trasnform from HDF5.
+        Create and initialize a new instance from parameters stored via Transform.save().
+        \param h5group HDF5 group to load parameters from.
+        \param manager EvolverManager responsible for the HDF5 file.
+        \param action Action to use.
+        \param lattice Lattice the simulation runs on.
+        \param rng Central random number generator for the run.
+        \returns A newly constructed transform.
+        """

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -61,7 +61,7 @@ class Transform(metaclass=ABCMeta):
 def backwardTransform(transform, stage):
     """!
     Backwards transform a configuration in an EvolutionStage and compute
-    Jacobian for forwards tranform if necessary.
+    Jacobian for forwards transform if necessary.
     """
 
     # there is no transform => Jacobian is zero
@@ -75,3 +75,15 @@ def backwardTransform(transform, stage):
 
     # Jacobian is unknown
     return transform.backward(stage.phi, True)
+
+def forwardTransform(transform, phi, actVal):
+    """!
+    Forwards transform a configuration and compute Jacobian.
+    """
+
+    # there is no transform
+    if transform is None:
+        return phi, actVal, 0
+
+    # delegate to the actual transform
+    return transform.forward(phi, actVal)

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -14,7 +14,7 @@ class Transform(metaclass=ABCMeta):
     @abstractmethod
     def forward(self, phi, actVal):
         r"""!
-        Transform a configuration from proposal to MC manifold.
+        %Transform a configuration from proposal to MC manifold.
         \param phi Configuration on proposal manifold.
         \param actVal Value of the action at phi.
         \returns In order:
@@ -26,7 +26,7 @@ class Transform(metaclass=ABCMeta):
     @abstractmethod
     def backward(self, phi, jacobian=False):
         r"""!
-        Transform a configuration from MC to proposal manifold.
+        %Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
         \returns
             - Configuration on proposal manifold
@@ -47,7 +47,7 @@ class Transform(metaclass=ABCMeta):
     @abstractmethod
     def fromH5(cls, h5group, manager, action, lattice, rng):
         r"""!
-        Construct a trasnform from HDF5.
+        Construct a transform from HDF5.
         Create and initialize a new instance from parameters stored via Transform.save().
         \param h5group HDF5 group to load parameters from.
         \param manager EvolverManager responsible for the HDF5 file.

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -28,9 +28,7 @@ class Transform(metaclass=ABCMeta):
         r"""!
         Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
-        \returns In order:
-          - Configuration on proposal manifold.
-          - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the *forward* transformation.
+        \returns Configuration on proposal manifold.
         """
 
     @abstractmethod

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -56,3 +56,22 @@ class Transform(metaclass=ABCMeta):
         \param rng Central random number generator for the run.
         \returns A newly constructed transform.
         """
+
+
+def backwardTransform(transform, stage):
+    """!
+    Backwards transform a configuration in an EvolutionStage and compute
+    Jacobian for forwards tranform if necessary.
+    """
+
+    # there is no transform => Jacobian is zero
+    if transform is None:
+        return stage.phi, 0
+
+    # Jacobian is known and stored in EvolutionStage
+    if "logdetJ" in stage.logWeights:
+        return transform.backward(stage.phi, False)[0], \
+            stage.logWeights["logdetJ"]
+
+    # Jacobian is unknown
+    return transform.backward(stage.phi, True)

--- a/src/isle/evolver/transform/transform.py
+++ b/src/isle/evolver/transform/transform.py
@@ -24,11 +24,14 @@ class Transform(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def backward(self, phi):
+    def backward(self, phi, jacobian=False):
         r"""!
         Transform a configuration from MC to proposal manifold.
         \param phi Configuration on MC manifold.
-        \returns Configuration on proposal manifold.
+        \returns
+            - Configuration on proposal manifold
+            - \f$\log \det J\f$ where \f$J\f$ is the Jacobian of the
+              *forwards* transformation. `None` if `jacobian==False`.
         """
 
     @abstractmethod

--- a/src/isle/h5io.py
+++ b/src/isle/h5io.py
@@ -30,6 +30,7 @@ def createH5Group(base, name):
     # does not exists yet
     return base.create_group(name)
 
+# TODO remove
 def writeDict(h5group, dictionary):
     """!
     Write a `dict` into an HDF5 group by storing each dict element as a dataset.
@@ -103,33 +104,21 @@ def initializeNewFile(fname, overwrite, lattice, params, makeActionSrc, extraGro
 
     writeMetadata(fname, lattice, params, makeActionSrc)
 
-def writeTrajectory(h5group, label, phi, actVal, trajPoint, weights):
+def writeTrajectory(h5group, label, stage):
     r"""!
     Write a trajectory (endpoint) to a HDF5 group.
-    Creates a new group with name 'label' and stores
-    Configuration, action, and whenther the trajectory was accepted.
+    Creates a new group with name 'label' and stores the EvolutionStage.
 
     \param h5group Base HDF5 group to store trajectory in.
     \param label Name of the subgroup of `h5group` to write to.
                  The subgroup must not already exist.
-    \param phi Configuration to save.
-    \param actVal Value of the action at configuration `phi`.
-    \param trajPoint Point on the trajectory that was accepted.
-                     `trajPoint==0` is the start point and values `>0` or `<0` are
-                     `trajPoint` MD steps after or before the start point.
-    \param weights Weights for re-weighting for configuration `phi`, not including the action.
-                     `dict` or `None`.
+    \param stage EvolutionStage to save.
 
     \returns The newly created HDF5 group containing the trajectory.
     """
 
     grp = h5group.create_group(str(label))
-    grp["phi"] = phi
-    grp["action"] = actVal
-    grp["trajPoint"] = trajPoint
-    if weights:
-        writeDict(grp.create_group("weights"), weights)
-
+    stage.save(grp)
     return grp
 
 def writeCheckpoint(h5group, label, rng, trajGrpName, evolver, evolverManager):
@@ -175,6 +164,7 @@ def loadCheckpoint(h5group, label, evolverManager, action, lattice):
     evolver = evolverManager.load(grp["evolver"], action, lattice, rng)
     return rng, phi, evolver
 
+# TODO return EvolutionStage
 def loadConfiguration(h5group, trajIdx=-1, path="configuration"):
     r"""!
     Load a configuration from HDF5.

--- a/src/isle/h5io.py
+++ b/src/isle/h5io.py
@@ -13,6 +13,7 @@ from . import Vector, isleVersion, pythonVersion, blazeVersion, pybind11Version
 from .random import readStateH5
 from .collection import listToSlice, parseSlice, subslice, normalizeSlice
 
+
 def createH5Group(base, name):
     r"""!
     Create a new HDF5 group if it does not yet exist.
@@ -155,14 +156,14 @@ def loadCheckpoint(h5group, label, evolverManager, action, lattice):
                           including its type.
     \param action Action to construct the evolver with.
     \param lattice Lattice to construct the evolver with.
-    \returns (RNG, configuration, evolver)
+    \returns (RNG, HDF5 group of configuration, evolver)
     """
 
     grp = h5group[str(label)]
     rng = readStateH5(grp["rngState"])
-    phi = Vector(grp["cfg/phi"][()])
+    cfgGrp = grp["cfg"]
     evolver = evolverManager.load(grp["evolver"], action, lattice, rng)
-    return rng, phi, evolver
+    return rng, cfgGrp, evolver
 
 def loadConfiguration(h5group, trajIdx=-1, path="configuration"):
     r"""!

--- a/src/isle/h5io.py
+++ b/src/isle/h5io.py
@@ -164,7 +164,6 @@ def loadCheckpoint(h5group, label, evolverManager, action, lattice):
     evolver = evolverManager.load(grp["evolver"], action, lattice, rng)
     return rng, phi, evolver
 
-# TODO return EvolutionStage
 def loadConfiguration(h5group, trajIdx=-1, path="configuration"):
     r"""!
     Load a configuration from HDF5.
@@ -175,7 +174,7 @@ def loadConfiguration(h5group, trajIdx=-1, path="configuration"):
                    plain index into the array of all configurations.
     \param path Path under `h5group` that contains configurations.
 
-    \returns (configuration, action value, trajectory point)
+    \returns (configuration, action value)
     """
 
     configs = loadList(h5group[path])
@@ -183,13 +182,7 @@ def loadConfiguration(h5group, trajIdx=-1, path="configuration"):
     idx = configs[-1][0]+trajIdx+1 if trajIdx < 0 else trajIdx
     # get the configuration group with the given index
     cfgGrp = next(pair[1] for pair in loadList(h5group[path]) if pair[0] == idx)
-    # load weights if present
-    try:
-        weights = loadDict(cfgGrp["weights"])
-    except KeyError:
-        weights = None
-
-    return Vector(cfgGrp["phi"][()]), cfgGrp["action"][()], cfgGrp["trajPoint"][()], weights
+    return Vector(cfgGrp["phi"][()]), cfgGrp["action"][()]
 
 def loadList(h5group, convert=int):
     r"""!

--- a/src/isle/h5io.py
+++ b/src/isle/h5io.py
@@ -128,7 +128,7 @@ def writeTrajectory(h5group, label, phi, actVal, trajPoint, weights):
     grp["action"] = actVal
     grp["trajPoint"] = trajPoint
     if weights:
-        writeDict(grp["weights"], weights)
+        writeDict(grp.create_group("weights"), weights)
 
     return grp
 


### PR DESCRIPTION
Refactor evolvers slightly and allow for transfomations between proposal and MC manifolds.
Evolvers now take EvolutionStage objects as parameters and return them.

This breaks compatibility both with existing code (the signature of the HMC driver has changed) and old HDF5 files (EvolverManager now handles Evolvers and Transforms which needed some changes in the interface).