### PR TITLE
Memoization

### DIFF
--- a/src/isle/__init__.py
+++ b/src/isle/__init__.py
@@ -11,6 +11,7 @@ from . import checks  # (unused import) pylint: disable=unused-import
 from . import cli  # (unused import) pylint: disable=unused-import
 from . import collection  # (unused import) pylint: disable=unused-import
 from . import fileio  # (unused import) pylint: disable=unused-import
+from . import memoize  # (unused import) pylint: disable=unused-import
 from . import meta  # (unused import) pylint: disable=unused-import
 from . import evolver  # (unused import) pylint: disable=unused-import
 from . import random  # (unused import) pylint: disable=unused-import

--- a/src/isle/meas/propagator.py
+++ b/src/isle/meas/propagator.py
@@ -7,9 +7,7 @@ import numpy as np
 from logging import getLogger
 
 import isle
-from ..util import spaceToSpacetime
-from ..h5io import createH5Group
-from .. import memoize
+from ..memoize import MemoizeMethod
 
 class AllToAll:
     r"""!
@@ -17,6 +15,11 @@ class AllToAll:
     Tabulate single-particle or hole all-to-all propagator.
     Given a field phi, return the inverse of the species-appropriate fermion matrix M[phi].
     The result is a four-index object Minverse[xf,tf,xi,ti].
+
+    \note The result of the most recent call is cached.
+          This result gets re-used automatically if the value of the action, trajectory point, and trajectory index
+          of subsequent calls are the same.
+          The actual configuration is not taken into account!
     """
 
     def __init__(self, hfm, species, alpha=1):
@@ -25,12 +28,10 @@ class AllToAll:
         self.species = species
         self._alpha = alpha
 
-    # @memoize.one_value_by("action", "itr") # TODO: make this memoization work.
-    # As it stands, it seems different instances share the same memoization,
-    # so we get the same propagator for particles as we get for holes,
-    # which is obviously problematic.
+    @MemoizeMethod(lambda stage, itr: (stage.logWeights["actVal"], stage.trajPoint, itr))
     def __call__(self, stage, itr):
-        """!Compute the all-to-all propagator.
+        r"""!
+        Compute the all-to-all propagator.
         \returns (Minverse)_{yfxi}, a 4D tensor where y/f is the space/time at the sink and x/i the space/time at the source.
         """
 

--- a/src/isle/meas/propagator.py
+++ b/src/isle/meas/propagator.py
@@ -36,8 +36,9 @@ class AllToAll:
         """
 
         if np.mod(len(stage.phi), self.nx) != 0:
-            getLogger(__name__).error(f"Field configuration does not partition evenly into spatial slices of size nx={nx}")
-            # TODO: do something more drastic?  Exit?
+            getLogger(__name__).error("Field configuration does not partition evenly into spatial slices of size nx=%d",
+                                      self.nx)
+            raise ValueError("Invalid field configuration")
 
         nt = int(len(stage.phi) / self.nx)
 

--- a/src/isle/memoize.py
+++ b/src/isle/memoize.py
@@ -30,7 +30,7 @@ class MemoizeMethod:
     <B>Example: Memoize by one argument</B><br>
     ```{.py}
     class C:
-        @MemoizeMethod("a")
+        @MemoizeMethod(lambda a: a)
         def f(self, a, b):
             print(f"evaluate f({a}, {b})")
 
@@ -50,7 +50,7 @@ class MemoizeMethod:
     <B>Example: Memoize by two arguments</B><br>
     ```{.py}
     class C:
-        @MemoizeMethod("a", "b")
+        @MemoizeMethod(lambda a, b: (a, b))
         def f(self, a, b):
             print(f"evaluate f({a}, {b})")
 
@@ -61,6 +61,24 @@ class MemoizeMethod:
     c1.f(1, 2)  # evaluated (a changed)
     c1.f(1, 2)  # re-used
     c1.f(0, 2)  # evaluated, only the most recent result is stored
+    ```
+
+    <B>Example: Memoize by derived properties</B><br>
+    ```{.py}
+    class C:
+        @MemoizeMethod(lambda s: len(s))
+        def f(self, s, x):
+            print(f"evaluate f({s}, {x})")
+            return len(s) + x
+
+    c1 = C()
+    c1.f("foo", 1)     # evaluated
+    c1.f("foo", 1)     # re-used
+    c1.f("bar", 1)     # re-used, only len(s) matters
+    c1.f("bar", 2)     # re-used
+    c1.f("foobar", 2)  # evaluated (len(s) changed)
+    c1.f("bazbar", 2)  # re-used
+    c1.f("foo", 2)     # evaluated, only the most recent result is stored
     ```
 
     \note The efficiency of this decorator depends on the equality operator (`==`).

--- a/src/isle/memoize.py
+++ b/src/isle/memoize.py
@@ -6,6 +6,7 @@ so that if the function is called again with the same arguments the result is ju
 """
 
 
+import functools
 import inspect
 import typing
 import weakref
@@ -105,6 +106,7 @@ class MemoizeMethod:
         memo = self  # Using 'self' inside of wrapper is confusing; 'memo' is the instance of Memoize.
         signature = self._getSignature(method)
 
+        @functools.wraps(method)
         def wrapper(instance, *args, **kwargs):
             memoized = memo._getOrInsertInstanceData(instance)
             actualArguments = _bindArguments(signature, instance, *args, **kwargs)

--- a/src/isle/memoize.py
+++ b/src/isle/memoize.py
@@ -63,7 +63,7 @@ class MemoizeMethod:
 
     def __call__(self, function):
         memo = self  # Using 'self' inside of wrapper is confusing; 'memo' is the instance of Memoize.
-        signature = inspect.signature(function)
+        signature = self._getSignature(function)
 
         def wrapper(instance, *args, **kwargs):
             memoized = memo._getOrInsertInstanceData(instance)
@@ -78,6 +78,16 @@ class MemoizeMethod:
             return memoized.result
 
         return wrapper
+
+    def _getSignature(self, function):
+        signature = inspect.signature(function)
+        for name in self.argnames:
+            if name not in signature.parameters:
+                getLogger(__name__).error("Argument name '%s' not in signature of function %s\n  signature: %s",
+                                          name, function, signature)
+                raise NameError(f"Argument name {name} if not part of function signature")
+
+        return signature
 
     def _getOrInsertInstanceData(self, instance):
         try:

--- a/src/isle/memoize.py
+++ b/src/isle/memoize.py
@@ -18,7 +18,9 @@ class MemoizeMethod:
     r"""!
     Decorator that memoizes the result of a method call based on given arguments.
 
-    @warning This decorator works only on bound methods not free functions.
+    \warning This decorator works only on bound methods not free functions.
+
+    \note Classes using this decorator on their methods must support hashing.
 
     The most recent result of calling the decorated method is cached and returned on subsequent
     calls if the specified arguments match those of the cached call.

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -1,0 +1,286 @@
+"""
+Test memoization.
+"""
+
+import gc
+import random
+import unittest
+
+from isle.memoize import MemoizeMethod
+
+
+class CallTracer:
+    def __init__(self):
+        self.neval = 0
+
+    def wasEvaluated(self, reset=False):
+        res = self.neval != 0
+        if reset:
+            self.reset()
+        return res
+
+    def reset(self):
+        self.neval = 0
+
+    def tick(self):
+        self.neval += 1
+
+
+class DelTracerManager:
+    class DelTracer:
+        def __init__(self, manager):
+            self.manager = manager
+
+        def __del__(self):
+            self.manager.release()
+
+    def __init__(self):
+        self.counter = 0
+
+    def ntraced(self):
+        return self.counter
+
+    def make(self):
+        self.counter += 1
+        return self.DelTracer(self)
+
+    def release(self):
+        assert self.counter > 0
+        self.counter -= 1
+
+
+class Class0:
+    def __init__(self, name):
+        self.name = name
+        self.tracer = CallTracer()
+
+    def undeco(self, a, b, c):
+        self.tracer.tick()
+        return self.name, a + b*100 + c*10000
+
+    @MemoizeMethod(lambda a, b, c: (a, b, c))
+    def decoAll(self, a, b, c):
+        return self.undeco(a, b, c)
+
+    @MemoizeMethod(lambda a, b: (a, b))
+    def decoAB(self, a, b, c):
+        return self.undeco(a, b, c)
+
+
+class Class1:
+    def __init__(self, name):
+        self.name = name
+        self.tracer = CallTracer()
+
+    def undeco(self, l, x):
+        self.tracer.tick()
+        return self.name, len(l) + x*100
+
+    @MemoizeMethod(lambda l, x: (len(l), x))
+    def decoAll(self, l, x):
+        return self.undeco(l, x)
+
+    @MemoizeMethod(lambda l: len(l))
+    def decol(self, l, x):
+        return self.undeco(l, x)
+
+
+class Class2:
+    @MemoizeMethod(lambda t: t)
+    def deco(self, t):
+        pass
+
+
+class Memoize(unittest.TestCase):
+    def test_compareNonMemoizedFull(self):
+        """
+        Compare decorated method with non-decorated one with memoization w.r.t all parameters.
+        """
+
+        c0 = Class0("c0")
+        args = [1, 2, 3]
+
+        for _ in range(100):
+            # change random arg or change none
+            changeIdx = random.randint(0, len(args))
+            if changeIdx != len(args):
+                args[changeIdx] = random.randint(-99, 99)
+
+            referenceVal = c0.undeco(*args)
+            decoVal = c0.decoAll(*args)
+            self.assertEqual(referenceVal, decoVal)
+
+    def test_compareNonMemoizedFullMulti(self):
+        """
+        Compare decorated method with non-decorated one with memoization w.r.t all parameters
+        on multiple instances.
+        """
+
+        cs = [Class0("c0"), Class0("c1"), Class0("c2")]
+        args = [1, 2, 3]
+
+        for _ in range(100):
+            # change random arg or change none
+            changeIdx = random.randint(0, len(args))
+            if changeIdx != len(args):
+                args[changeIdx] = random.randint(-99, 99)
+            c = random.choice(cs)
+
+            referenceVal = c.undeco(*args)
+            decoVal = c.decoAll(*args)
+            self.assertEqual(referenceVal, decoVal)
+
+    def test_compareNonMemoizedPartial(self):
+        """
+        Compare decorated method with non-decorated one with memoization w.r.t one parameter.
+        """
+
+        c0 = Class0("c0")
+        args = [1, 2, 3]
+        previous = None
+
+        for _ in range(100):
+            # change random arg or change none
+            changeIdx = random.randint(0, len(args))
+            if changeIdx != len(args):
+                args[changeIdx] = random.randint(-99, 99)
+
+            referenceVal = c0.undeco(*args)
+            decoVal = c0.decoAB(*args)
+            if changeIdx >= len(args)-1:
+                # Either argument c was changed or none
+                #   => decorated method should return the same as before.
+                if previous is not None:  # If this is the first call, just skip it.
+                    self.assertEqual(previous, decoVal)
+            else:
+                # a or b was changed, memoization has to pick it up.
+                self.assertEqual(referenceVal, decoVal)
+            previous = decoVal
+
+    def test_traceEvaluationClass0(self):
+        """
+        Run some manually constructed scenarios with Class0.
+        """
+
+        c0 = Class0("c0")
+        # memoize w.r.t all arguments
+        c0.decoAll(0, 1, 2)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll(0, 1, 2)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decoAll(0, 1, 1)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll(1, 1, 1)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll(1, 1, 1)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+
+        # memoize w.r.t first two arguments
+        c0.decoAB(1, 1, 1)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAB(1, 1, 2)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decoAB(1, 2, 2)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAB(1, 2, 2)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+
+        c1 = Class0("c1")
+        # two instances to not interfere
+        c0.decoAB(1, 2, 2)
+        c1.decoAB(1, 2, 2)
+        self.assertTrue(c1.tracer.wasEvaluated(True))
+        c0.decoAll(1, 2, 2)
+        c1.decoAll(1, 2, 2)
+        self.assertTrue(c1.tracer.wasEvaluated(True))
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+
+    def test_traceEvaluationClass1(self):
+        """
+        Run some manually constructed scenarios with Class1.
+        """
+
+        c0 = Class1("c0")
+        # memoize w.r.t all arguments
+        c0.decoAll([1, 2], 7)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll([1, 2], 7)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decoAll([1, 3], 7)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decoAll([1, 2, 3], 7)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll([1, 2, 3], 8)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decoAll([1, 2, 3], 8)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+
+        # memoize w.r.t. first argument
+        c0.decol([1, 2, 3], 8)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decol([1, 2, 3], 8)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decol([1, 2, 3], 7)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decol([1, 2], 7)
+        self.assertTrue(c0.tracer.wasEvaluated(True))
+        c0.decol([1, 2], 7)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+        c0.decol([2, 2], 7)
+        self.assertFalse(c0.tracer.wasEvaluated(True))
+
+    def test_resourceManagement(self):
+        """
+        Test whether caches are freed when an object goes out of scope.
+        """
+
+        tracerManager = DelTracerManager()
+        self.assertEqual(0, tracerManager.ntraced())
+
+        c0 = Class2()
+        c0.deco(tracerManager.make())
+        self.assertEqual(1, tracerManager.ntraced())
+        # evict previous tracer from cache
+        c0.deco(tracerManager.make())
+        gc.collect()
+        self.assertEqual(1, tracerManager.ntraced())
+        # remove object, should remove cache as well
+        del c0
+        gc.collect()
+        self.assertEqual(0, tracerManager.ntraced())
+
+        c0 = Class2()
+        c1 = Class2()
+        c0.deco(tracerManager.make())
+        self.assertEqual(1, tracerManager.ntraced())
+        c1.deco(tracerManager.make())
+        self.assertEqual(2, tracerManager.ntraced())
+        # evict in c0
+        c0.deco(tracerManager.make())
+        gc.collect()
+        self.assertEqual(2, tracerManager.ntraced())
+        # evict in c1
+        c1.deco(tracerManager.make())
+        gc.collect()
+        self.assertEqual(2, tracerManager.ntraced())
+        # remove c0
+        del c0
+        gc.collect()
+        self.assertEqual(1, tracerManager.ntraced())
+        # create new instance
+        c2 = Class2()
+        self.assertEqual(1, tracerManager.ntraced())
+        c2.deco(tracerManager.make())
+        self.assertEqual(2, tracerManager.ntraced())
+        # remove c2
+        del c2
+        gc.collect()
+        self.assertEqual(1, tracerManager.ntraced())
+        # remove c1
+        del c1
+        gc.collect()
+        self.assertEqual(0, tracerManager.ntraced())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement memoization for methods.

Replaces `one_value_by` by `MemoizeMethod` which can handle bound methods.
Also provides a more general syntax for specifying how to identify cache entries.

The new decorator is applied to `AllToAll`.