### PR TITLE
Sign convention

### DIFF
--- a/docs/algorithm/hubbardFermiAction.tex
+++ b/docs/algorithm/hubbardFermiAction.tex
@@ -123,7 +123,7 @@ The fermion matrix discussed in the previous section is an approximation of
 with
 \begin{align}
   {\hat{K}}_{x'x} &\equiv \delta_{x'x}\\
-  {\hat{F}_{t'}(\phi, \tilde{\kappa}, \tilde{\mu})}_{x'x} &\equiv {(e^{-\tilde{\kappa}+\tilde{\mu}})}_{x'x} e^{\i \phi_{x(t'-1)}} = {(e^{-\tilde{\kappa}+\tilde{\mu}} F_{t'}(\phi) )}_{x'x}.
+  {\hat{F}_{t'}(\phi, \tilde{\kappa}, \tilde{\mu})}_{x'x} &\equiv {(e^{\tilde{\kappa}-\tilde{\mu}})}_{x'x} e^{\i \phi_{x(t'-1)}} = {(e^{\tilde{\kappa}-\tilde{\mu}} F_{t'}(\phi) )}_{x'x}.
 \end{align}
 And the combination
 \begin{align}
@@ -132,9 +132,9 @@ And the combination
 \end{align}
 with
 \begin{align}
-  {\hat{P}(\tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= \delta_{x'x} + {(e^{-\tilde{\kappa}+\tilde{\mu}} e^{-\sigma_{\tilde{\kappa}}\tilde{\kappa} - \tilde{\mu}})}_{x'x}\\
-  {\hat{T}^+_{t'}(\phi, \tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= - \mathcal{B}_{t'} {\hat{F}_{t'}(\phi, \tilde{\kappa}, \tilde{\mu})}_{x'x} = - \mathcal{B}_{t'} {(e^{-\tilde{\kappa}+\tilde{\mu}})}_{x'x} e^{\i \phi_{x(t'-1)}}\\
-  {\hat{T}^-_{t'}(\phi, \tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= - \mathcal{B}_{t'+1} {\hat{F}^T_{t'+1}(-\phi, \sigma_{\tilde{\kappa}}\tilde{\kappa}, -\tilde{\mu})}_{x'x} = - \mathcal{B}_{t'+1} e^{-\i \phi_{x't'}} {(e^{-\sigma_{\tilde{\kappa}}\tilde{\kappa}-\tilde{\mu}})}_{x'x}
+  {\hat{P}(\tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= \delta_{x'x} + {(e^{\tilde{\kappa}-\tilde{\mu}} e^{\sigma_{\tilde{\kappa}}\tilde{\kappa} + \tilde{\mu}})}_{x'x}\\
+  {\hat{T}^+_{t'}(\phi, \tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= - \mathcal{B}_{t'} {\hat{F}_{t'}(\phi, \tilde{\kappa}, \tilde{\mu})}_{x'x} = - \mathcal{B}_{t'} {(e^{+\tilde{\kappa}-\tilde{\mu}})}_{x'x} e^{\i \phi_{x(t'-1)}}\\
+  {\hat{T}^-_{t'}(\phi, \tilde{\kappa}, \tilde{\mu}, \sigma_{\tilde{\kappa}})}_{x'x} &= - \mathcal{B}_{t'+1} {\hat{F}^T_{t'+1}(-\phi, \sigma_{\tilde{\kappa}}\tilde{\kappa}, -\tilde{\mu})}_{x'x} = - \mathcal{B}_{t'+1} e^{-\i \phi_{x't'}} {(e^{\sigma_{\tilde{\kappa}}\tilde{\kappa}+\tilde{\mu}})}_{x'x}
 \end{align}
 Since both $\hat{M}$ and $\hat{Q}$ have the same block structure as $M$ and $Q$, most of the following derivations treat only the diagonal discretization from Section~\ref{sec:dia_disc}.
 Based on those, results for the exponential discretization are derived where they differ.

--- a/docs/algorithm/hubbardFermiAction.tex
+++ b/docs/algorithm/hubbardFermiAction.tex
@@ -258,7 +258,7 @@ For this reason, the hole determinant should be calculated using the following, 
 \begin{resultbox}
   \vspace{-\baselineskip}
   \begin{align}
-    \log \det \hat{M}_h &= -\i \Phi  - N_t \log \det e^{\sigma_{\tilde{\kappa}}\kappa+\mu} + \log \det (1 + \hat{A}^{-1}),\label{eq:det_M_exp_h}\\
+    \log \det \hat{M}_h &= -\i \Phi  - N_t \log \det e^{-\sigma_{\tilde{\kappa}}\kappa-\mu} + \log \det (1 + \hat{A}^{-1}),\label{eq:det_M_exp_h}\\
     \hat{A}^{-1} &\equiv \hat{F}_0^{-1} \hat{F}_1^{-1} \cdots \hat{F}_{N_t-1}^{-1}
   \end{align}
 \end{resultbox}

--- a/src/isle/cpp/hubbardFermiMatrixExp.cpp
+++ b/src/isle/cpp/hubbardFermiMatrixExp.cpp
@@ -590,7 +590,7 @@ namespace isle {
             return toFirstLogBranch(ilogdet(B));
         }
 
-        // Use version -i Phi - N_t log(det(e^{sigmaKappa*kappa+mu})) + log(det(1+hat{A}^{-1})).
+        // Use version -i Phi - N_t log(det(e^{-sigmaKappa*kappa-mu})) + log(det(1+hat{A}^{-1})).
         std::complex<double> logdetM_h(const HubbardFermiMatrixExp &hfm,
                                        const CDVector &phi) {
             const auto NX = hfm.nx();

--- a/src/isle/cpp/hubbardFermiMatrixExp.cpp
+++ b/src/isle/cpp/hubbardFermiMatrixExp.cpp
@@ -29,15 +29,15 @@ namespace isle {
             switch (species) {
             case Species::PARTICLE:
                 if (inv) {
-                    return expmSym(kappa - mu*IdMatrix<double>(kappa.rows()));
-                } else {
                     return expmSym(-kappa + mu*IdMatrix<double>(kappa.rows()));
+                } else {
+                    return expmSym(kappa - mu*IdMatrix<double>(kappa.rows()));
                 }
             case Species::HOLE:
                 if (inv) {
-                    return expmSym(sigmaKappa*kappa + mu*IdMatrix<double>(kappa.rows()));
-                } else {
                     return expmSym(-sigmaKappa*kappa - mu*IdMatrix<double>(kappa.rows()));
+                } else {
+                    return expmSym(sigmaKappa*kappa + mu*IdMatrix<double>(kappa.rows()));
                 }
             }
             // Strictly speaking impossible to reach but gcc complains.
@@ -590,7 +590,7 @@ namespace isle {
             return toFirstLogBranch(ilogdet(B));
         }
 
-        // Use version -i Phi + N_t log(det(e^{sigmaKappa*kappa+mu})) + log(det(1+hat{A}^{-1})).
+        // Use version -i Phi - N_t log(det(e^{sigmaKappa*kappa+mu})) + log(det(1+hat{A}^{-1})).
         std::complex<double> logdetM_h(const HubbardFermiMatrixExp &hfm,
                                        const CDVector &phi) {
             const auto NX = hfm.nx();

--- a/src/isle/cpp/hubbardFermiMatrixExp.hpp
+++ b/src/isle/cpp/hubbardFermiMatrixExp.hpp
@@ -253,13 +253,13 @@ namespace isle {
         double _mu;  ///< Chemical potential.
         std::int8_t _sigmaKappa;  ///< Sign of kappa in M^dag.
 
-        /// exp(-kappaTilde+muTilde) for particles.
-        DMatrix _expKappap;
         /// exp(kappaTilde-muTilde) for particles.
+        DMatrix _expKappap;
+        /// exp(-kappaTilde+muTilde) for particles.
         DMatrix _expKappapInv;
-        /// exp(-sigmaKappa*kappaTilde-muTilde) for holes.
-        DMatrix _expKappah;
         /// exp(sigmaKappa*kappaTilde+muTilde) for holes.
+        DMatrix _expKappah;
+        /// exp(-sigmaKappa*kappaTilde-muTilde) for holes.
         DMatrix _expKappahInv;
         /// log(det(_expKappahInv)).
         std::complex<double> _logdetExpKappahInv;

--- a/src/isle/cpp/hubbardFermiMatrixExp.hpp
+++ b/src/isle/cpp/hubbardFermiMatrixExp.hpp
@@ -26,8 +26,8 @@ namespace isle {
      *
      * Neither the full matrices nor any of their blocks are stored explicitly. Instead,
      * each block is to be constructed when needed which might be expensive.
-     * The only exception is \f$e^{\tilde{\kappa}-\tilde{\mu}}\f$ which is cached
-     * after it has been requested through HubbardFermiMatrixExp::expKappa() for the first time.
+     * The only exception is \f$e^{\tilde{\kappa}-\tilde{\mu}}\f$ which is stored for particles and holes, both
+     * as the matrices themselves and their inverses.
      *
      * The result of an LU-decomposition of \f$\hat{Q}\f$ is stored in HubbardFermiMatrixExp::LU
      * to save memory and give easier access to the components compared to a `blaze::Matrix`.

--- a/src/isle/cpp/hubbardFermiMatrixExp.hpp
+++ b/src/isle/cpp/hubbardFermiMatrixExp.hpp
@@ -26,7 +26,7 @@ namespace isle {
      *
      * Neither the full matrices nor any of their blocks are stored explicitly. Instead,
      * each block is to be constructed when needed which might be expensive.
-     * The only exception is \f$e^{-\tilde{\kappa}+\tilde{\mu}}\f$ which is cached
+     * The only exception is \f$e^{\tilde{\kappa}-\tilde{\mu}}\f$ which is cached
      * after it has been requested through HubbardFermiMatrixExp::expKappa() for the first time.
      *
      * The result of an LU-decomposition of \f$\hat{Q}\f$ is stored in HubbardFermiMatrixExp::LU
@@ -64,10 +64,11 @@ namespace isle {
         HubbardFermiMatrixExp &operator=(HubbardFermiMatrixExp &&) = default;
         ~HubbardFermiMatrixExp() = default;
 
-        /// Return the exponential of the hopping amtrix and chemical potential.
+        /// Return the exponential of the hopping matrix and chemical potential.
         /**
-         * \returns \f$\exp(-\tilde{\kappa} + \tilde{\mu})\f$ for particles
-         *          and \f$\exp(-\sigma_{\tilde{\kappa}}\tilde{\kappa} - \tilde{\mu})\f$ for holes.
+         * \returns \f$\exp(\tilde{\kappa} - \tilde{\mu})\f$ for particles
+         *          and \f$\exp(\sigma_{\tilde{\kappa}}\tilde{\kappa} + \tilde{\mu})\f$ for holes
+         *          or the inverses if `inv == true`.
          */
         const DMatrix &expKappa(const Species species, const bool inv) const;
 

--- a/tests/test_hubbardFermiMatrix.py
+++ b/tests/test_hubbardFermiMatrix.py
@@ -137,7 +137,7 @@ class TestHubbardFermiMatrix(unittest.TestCase):
                           msg="logdetM must throw a RuntimeError when called with mu != 0. If this bug has been fixed, update the unit test!")
 
         for nt, beta,  mu, sigmaKappa, species, rep in itertools.product((4, 8, 32),
-                                                                         (3, 6, 10),
+                                                                         (3, 6),
                                                                          [0],
                                                                          (-1, 1),
                                                                          (isle.Species.PARTICLE, isle.Species.HOLE),


### PR DESCRIPTION
Change the sign of the hopping matrix and chemical potential in the exponential discretization to match the diagonal. As discussed in #17 