### PR TITLE
New Bilinear Routine

### DIFF
--- a/docs/examples/measure.py
+++ b/docs/examples/measure.py
@@ -64,41 +64,41 @@ def main():
     # overwritten by accident.
     measurements = [
         # log(det(M)) where M is the fermion matrix
-        isle.meas.Logdet(hfm, "logdet"),
+        # isle.meas.Logdet(hfm, "logdet"),
         # \sum_i phi_i
-        isle.meas.TotalPhi("field"),
+        # isle.meas.TotalPhi("field"),
         # collect all weights and store them in consolidated datasets instead of
         # spread out over many HDF5 groups
-        isle.meas.CollectWeights("weights"),
+        # isle.meas.CollectWeights("weights"),
         # polyakov loop
-        isle.meas.Polyakov(params.basis, lat.nt(), "polyakov", configSlice=s_[::10]),
+        # isle.meas.Polyakov(params.basis, lat.nt(), "polyakov", configSlice=s_[::10]),
         # one-point functions
-        isle.meas.onePointFunctions(allToAll[isle.Species.PARTICLE],
+        isle.meas.onePointFunctions.measurement(allToAll[isle.Species.PARTICLE],
                                             allToAll[isle.Species.HOLE],
                                             "correlation_functions/one_point",
                                             configSlice=s_[::10],
                                             transform=None),
         # single particle correlator for particles / spin up
-        isle.meas.SingleParticleCorrelator(allToAll[isle.Species.PARTICLE],
-                                           "correlation_functions/single_particle",
-                                           configSlice=s_[::10],
-                                           projector=projector),
+        # isle.meas.SingleParticleCorrelator(allToAll[isle.Species.PARTICLE],
+        #                                    "correlation_functions/single_particle",
+        #                                    configSlice=s_[::10],
+        #                                    projector=projector),
         # single particle correlator for holes / spin down
-        isle.meas.SingleParticleCorrelator(allToAll[isle.Species.HOLE],
-                                           "correlation_functions/single_hole",
-                                           configSlice=s_[::10],
-                                           projector=projector),
-        isle.meas.SpinSpinCorrelator(allToAll[isle.Species.PARTICLE],
-                                            allToAll[isle.Species.HOLE],
-                                            "correlation_functions/spin_spin",
-                                            configSlice=s_[::10],
-                                            transform=projector,
-                                            sigmaKappa=params.sigmaKappa),
-        isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
-                                            allToAll[isle.Species.HOLE],
-                                            "correlation_functions/det",
-                                            configSlice=s_[::10],
-                                            )
+        # isle.meas.SingleParticleCorrelator(allToAll[isle.Species.HOLE],
+        #                                    "correlation_functions/single_hole",
+        #                                    configSlice=s_[::10],
+        #                                    projector=projector),
+        # isle.meas.SpinSpinCorrelator(allToAll[isle.Species.PARTICLE],
+        #                                     allToAll[isle.Species.HOLE],
+        #                                     "correlation_functions/spin_spin",
+        #                                     configSlice=s_[::10],
+        #                                     transform=projector,
+        #                                     sigmaKappa=params.sigmaKappa),
+        # isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
+        #                                     allToAll[isle.Species.HOLE],
+        #                                     "correlation_functions/det",
+        #                                     configSlice=s_[::10],
+        #                                     )
     ]
 
     # Run the measurements on all configurations in the input file.

--- a/docs/examples/measure.py
+++ b/docs/examples/measure.py
@@ -50,7 +50,7 @@ def main():
     species =   (isle.Species.PARTICLE, isle.Species.HOLE)
     allToAll = {s: isle.meas.propagator.AllToAll(hfm, s) for s in species}
 
-    _, projector = np.linalg.eigh(isle.Matrix(hfm.kappaTilde()))
+    _, diagonalize = np.linalg.eigh(isle.Matrix(hfm.kappaTilde()))
 
     #
     # The measurements are run on each configuration in the slice passed to 'configSlice'.
@@ -82,17 +82,17 @@ def main():
         isle.meas.SingleParticleCorrelator(allToAll[isle.Species.PARTICLE],
                                            "correlation_functions/single_particle",
                                            configSlice=s_[::10],
-                                           projector=projector),
+                                           transform=diagonalize),
         # single particle correlator for holes / spin down
         isle.meas.SingleParticleCorrelator(allToAll[isle.Species.HOLE],
                                            "correlation_functions/single_hole",
                                            configSlice=s_[::10],
-                                           projector=projector),
+                                           transform=diagonalize),
         isle.meas.SpinSpinCorrelator(allToAll[isle.Species.PARTICLE],
                                      allToAll[isle.Species.HOLE],
                                      "correlation_functions/spin_spin",
                                      configSlice=s_[::10],
-                                     transform=projector,
+                                     transform=diagonalize,
                                      sigmaKappa=params.sigmaKappa),
         isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
                                          allToAll[isle.Species.HOLE],

--- a/docs/examples/measure.py
+++ b/docs/examples/measure.py
@@ -64,46 +64,47 @@ def main():
     # overwritten by accident.
     measurements = [
         # log(det(M)) where M is the fermion matrix
-        # isle.meas.Logdet(hfm, "logdet"),
+        isle.meas.Logdet(hfm, "logdet"),
         # \sum_i phi_i
-        # isle.meas.TotalPhi("field"),
+        isle.meas.TotalPhi("field"),
         # collect all weights and store them in consolidated datasets instead of
         # spread out over many HDF5 groups
-        # isle.meas.CollectWeights("weights"),
+        isle.meas.CollectWeights("weights"),
         # polyakov loop
-        # isle.meas.Polyakov(params.basis, lat.nt(), "polyakov", configSlice=s_[::10]),
+        isle.meas.Polyakov(params.basis, lat.nt(), "polyakov", configSlice=s_[::10]),
         # one-point functions
-        isle.meas.onePointFunctions.measurement(allToAll[isle.Species.PARTICLE],
-                                            allToAll[isle.Species.HOLE],
-                                            "correlation_functions/one_point",
-                                            configSlice=s_[::10],
-                                            transform=None),
+        isle.meas.OnePointFunctions(allToAll[isle.Species.PARTICLE],
+                                    allToAll[isle.Species.HOLE],
+                                    "correlation_functions/one_point",
+                                    configSlice=s_[::10],
+                                    transform=None),
         # single particle correlator for particles / spin up
-        # isle.meas.SingleParticleCorrelator(allToAll[isle.Species.PARTICLE],
-        #                                    "correlation_functions/single_particle",
-        #                                    configSlice=s_[::10],
-        #                                    projector=projector),
+        isle.meas.SingleParticleCorrelator(allToAll[isle.Species.PARTICLE],
+                                           "correlation_functions/single_particle",
+                                           configSlice=s_[::10],
+                                           projector=projector),
         # single particle correlator for holes / spin down
-        # isle.meas.SingleParticleCorrelator(allToAll[isle.Species.HOLE],
-        #                                    "correlation_functions/single_hole",
-        #                                    configSlice=s_[::10],
-        #                                    projector=projector),
-        # isle.meas.SpinSpinCorrelator(allToAll[isle.Species.PARTICLE],
-        #                                     allToAll[isle.Species.HOLE],
-        #                                     "correlation_functions/spin_spin",
-        #                                     configSlice=s_[::10],
-        #                                     transform=projector,
-        #                                     sigmaKappa=params.sigmaKappa),
-        # isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
-        #                                     allToAll[isle.Species.HOLE],
-        #                                     "correlation_functions/det",
-        #                                     configSlice=s_[::10],
-        #                                     )
+        isle.meas.SingleParticleCorrelator(allToAll[isle.Species.HOLE],
+                                           "correlation_functions/single_hole",
+                                           configSlice=s_[::10],
+                                           projector=projector),
+        isle.meas.SpinSpinCorrelator(allToAll[isle.Species.PARTICLE],
+                                     allToAll[isle.Species.HOLE],
+                                     "correlation_functions/spin_spin",
+                                     configSlice=s_[::10],
+                                     transform=projector,
+                                     sigmaKappa=params.sigmaKappa),
+        isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
+                                         allToAll[isle.Species.HOLE],
+                                         "correlation_functions/det",
+                                         configSlice=s_[::10],
+        )
     ]
 
     # Run the measurements on all configurations in the input file.
     # This automatically saves all results to the output file when done.
     measState(measurements)
+
 
 if __name__ == "__main__":
     main()

--- a/docs/examples/measure.py
+++ b/docs/examples/measure.py
@@ -92,7 +92,7 @@ def main():
                                             allToAll[isle.Species.HOLE],
                                             "correlation_functions/spin_spin",
                                             configSlice=s_[::10],
-                                            projector=projector,
+                                            transform=projector,
                                             sigmaKappa=params.sigmaKappa),
         isle.meas.DeterminantCorrelators(allToAll[isle.Species.PARTICLE],
                                             allToAll[isle.Species.HOLE],

--- a/src/isle/meas/__init__.py
+++ b/src/isle/meas/__init__.py
@@ -13,6 +13,7 @@ from .logdet import Logdet  # (unused import) pylint: disable=W0611
 from .singleParticleCorrelator import SingleParticleCorrelator  # (unused import) pylint: disable=W0611
 from .totalPhi import TotalPhi  # (unused import) pylint: disable=W0611
 from .polyakov import Polyakov
-from .onePointFunctions import onePointFunctions
-from .spinSpinCorrelator import SpinSpinCorrelator
 from .determinantCorrelators import DeterminantCorrelators
+
+import isle.meas.onePointFunctions
+import isle.meas.spinSpinCorrelator

--- a/src/isle/meas/__init__.py
+++ b/src/isle/meas/__init__.py
@@ -10,10 +10,9 @@ from .action import Action  # (unused import) pylint: disable=W0611
 from .chiralCondensate import ChiralCondensate  # (unused import) pylint: disable=W0611
 from .collectWeights import CollectWeights  # (unused import) pylint: disable=W0611
 from .logdet import Logdet  # (unused import) pylint: disable=W0611
+from .onePointFunctions import OnePointFunctions  # (unused import) pylint: disable=W0611
 from .singleParticleCorrelator import SingleParticleCorrelator  # (unused import) pylint: disable=W0611
+from .spinSpinCorrelator import SpinSpinCorrelator  # (unused import) pylint: disable=W0611
 from .totalPhi import TotalPhi  # (unused import) pylint: disable=W0611
-from .polyakov import Polyakov
-from .determinantCorrelators import DeterminantCorrelators
-
-import isle.meas.onePointFunctions
-import isle.meas.spinSpinCorrelator
+from .polyakov import Polyakov  # (unused import) pylint: disable=W0611
+from .determinantCorrelators import DeterminantCorrelators  # (unused import) pylint: disable=W0611

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -128,29 +128,30 @@ class OnePointFunctions(Measurement):
         for name, correlator in self.correlators.items():
             subGroup[name] = correlator
 
-def computeDerivedCorrelators(measurements):
-    r"""!
-    \param measurements a dictionary of measurements that has measurements of `"np"` and `"nh"`
+    @classmethod
+    def computeDerivedCorrelators(cls, measurements):
+        r"""!
+        \param measurements a dictionary of measurements that has measurements of `"np"` and `"nh"`
 
-    Measurements of one-point functions \f$\rho_x\f$, \f$n_x\f$,
-    and \f$S^3_x\f$ are built from measurements of \f$n^p_x\f$ and \f$n^h_x\f$
-    using the identities above.
+        Measurements of one-point functions \f$\rho_x\f$, \f$n_x\f$,
+        and \f$S^3_x\f$ are built from measurements of \f$n^p_x\f$ and \f$n^h_x\f$
+        using the identities above.
 
-    This can be used with the following example codeblock
+        This can be used with the following example codeblock
 
-    ```python
-       # meas is an instance of OnePointFunctions
-        derived = isle.meas.onePointFunctions.computeDerivedCorrelators(
-            {name: np.asarray(corr) for name, corr in meas.correlators.items()})
-    ```
+        ```python
+           # meas is an instance of OnePointFunctions
+            derived = isle.meas.onePointFunctions.computeDerivedCorrelators(
+                {name: np.asarray(corr) for name, corr in meas.correlators.items()})
+        ```
 
-    \returns `dict` with additional one-point functions, built from those already computed.
-    """
+        \returns `dict` with additional one-point functions, built from those already computed.
+        """
 
-    derived = dict()
+        derived = dict()
 
-    derived["rho"] = measurements["np"] - measurements["nh"]
-    derived["n"]   = measurements["np"] + measurements["nh"]
-    derived["S3"]  = 0.5 * (1 - derived["n"])
+        derived["rho"] = measurements["np"] - measurements["nh"]
+        derived["n"]   = measurements["np"] + measurements["nh"]
+        derived["S3"]  = 0.5 * (1 - derived["n"])
 
-    return derived
+        return derived

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -141,7 +141,7 @@ class OnePointFunctions(Measurement):
 
         ```python
            # meas is an instance of OnePointFunctions
-            derived = isle.meas.onePointFunctions.computeDerivedCorrelators(
+            derived = isle.meas.OnePointFunctions.computeDerivedCorrelators(
                 {name: np.asarray(corr) for name, corr in meas.correlators.items()})
         ```
 

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -50,7 +50,7 @@ fields = ["np", "nh"]
 
 #TODO: save / retrieve einsum paths.
 
-class measurement(Measurement):
+class onePointFunctions(Measurement):
     r"""!
     \ingroup meas
     Tabulate one-point correlators.
@@ -121,7 +121,7 @@ class measurement(Measurement):
         for field in self.data:
             subGroup[field] = self.data[field]
 
-def useIdentities(measurements):
+def computeDerivedCorrelators(measurements):
     r"""!
     \param measurements a dictionary of measurements that has measurements of `"np"` and `"nh"`
 

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -141,17 +141,10 @@ def complete(measurements):
     \returns a dictionary with additional one-point functions, built from those already computed.
     """
 
-    try:
-        rest = dict()
+    rest = dict()
 
-        rest["rho"] = measurements["np"] - measurements["nh"]
-        rest["N"]   = measurements["np"] + measurements["nh"]
-        rest["S3"]  = 0.5 * ( 1 - rest["N"])
+    rest["rho"] = measurements["np"] - measurements["nh"]
+    rest["N"]   = measurements["np"] + measurements["nh"]
+    rest["S3"]  = 0.5 * ( 1 - rest["N"])
 
-        return {**measurements, **rest}
-
-    except KeyError:
-        raise KeyError(f"Needed fields np, nh are not both available in {measurements.keys()}")
-
-    except ValueError:
-        raise ValueError("Particle and hole one-point measurements are incompatible shapes, {measurements['np'].shape} and {measurements['nh'].shape}, respectively.")
+    return {**measurements, **rest}

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -121,32 +121,6 @@ class measurement(Measurement):
         for field in self.data:
             subGroup[field] = self.data[field]
 
-def read(h5group):
-    r"""!
-    \param h5group HDF5 group which contains the data of this measurement.
-
-    \returns A dictionary of measurements and a basis transformation, \n
-    {    \n
-        `np`: \f$n^p_x\f$,                      \n
-        `nh`: \f$n^h_x\f$,                      \n
-        `onePoint-transform`: A transformation from position space to another space \n
-        }
-    where both \f$n^{p,h}_x\f$ have the shape [measurements, spatial dimension] as long as `onePoint-transform` is square.
-    """
-
-    try:
-        data = {key: h5group[key][()] for key in h5group}
-
-        if type(data['transform']) is h5.Empty:
-            data['transform'] = None
-
-        data['onePoint-transform'] = data['transform']
-        del data['transform']
-
-        return data
-    except:
-        raise KeyError(f"Problem reading onePointFunction measurements from {h5group.name}")
-
 def complete(measurements):
     r"""!
     \param measurements a dictionary of measurements, like what is returned from read().

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -9,10 +9,14 @@ described in the SpinSpinCorrelator documentation to compute one-point functions
 All the vacuum quantum number bilinears can be written as combinations of the
 number operators,
 \f{align}{
-    n^p_x & = \left\langle 1-a_x a_x^\dagger \right\rangle
+    \left\langle n^p_x \right\rangle
+          & = \left\langle a_x^\dagger a_x \right\rangle
+            = \left\langle 1-a_x a_x^\dagger \right\rangle
             = \left\langle 1-P_{xx} \right\rangle
     \\
-    n^h_x & = \left\langle 1-b_x b_x^\dagger \right\rangle
+    \left\langle n^h_x \right\rangle
+          & = \left\langle b_x^\dagger b_x \right\rangle
+            = \left\langle 1-b_x b_x^\dagger \right\rangle
             = \left\langle 1-H_{xx} \right\rangle
 \f}
 For example, the expected charge density operator

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -52,10 +52,18 @@ class OnePointFunctions(Measurement):
     Tabulate one-point correlators.
     """
 
-    ##! Set of names of all possible elementary one-point-functions.
+    ## Set of names of all possible elementary one-point-functions.
     CORRELATOR_NAMES = {"np", "nh"}
 
     def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None), transform=None):
+        r"""!
+        \param particleAllToAll propagator.AllToAll for particles.
+        \param holesAllToAll propagator.AllToAll for holes.
+        \param savePath Path in the output file where results are saved.
+        \param configSlice `slice` indicating which configurations to measure on.
+        \param transform Transformation matrix applied to correlators in position space.
+        """
+
         super().__init__(savePath, configSlice)
 
         # The correlation functions encoded here are between bilinear operators.

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -121,7 +121,7 @@ class measurement(Measurement):
         for field in self.data:
             subGroup[field] = self.data[field]
 
-def complete(measurements):
+def useIdentities(measurements):
     r"""!
     \param measurements a dictionary of measurements that has measurements of `"np"` and `"nh"`
 

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -50,7 +50,7 @@ fields = ["np", "nh"]
 
 #TODO: save / retrieve einsum paths.
 
-class onePointFunctions(Measurement):
+class OnePointFunctions(Measurement):
     r"""!
     \ingroup meas
     Tabulate one-point correlators.

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -41,7 +41,9 @@ from .measurement import Measurement
 from ..util import temporalRoller
 from ..h5io import createH5Group
 
-class onePointFunctions(Measurement):
+fields = ["np", "nh"]
+
+class measurement(Measurement):
     r"""!
     \ingroup meas
     Tabulate one-point correlators.
@@ -57,7 +59,7 @@ class onePointFunctions(Measurement):
         self.particle=particleAllToAll
         self.hole=holeAllToAll
 
-        self.data = {k: [] for k in ["np", "nh"]}
+        self.data = {k: [] for k in fields}
 
         self.transform = transform
 
@@ -106,4 +108,14 @@ def read(h5group):
     r"""!
     \param h5group HDF5 group which contains the data of this measurement.
     """
-    ...
+    return {key: h5group[key][()] for key in h5group}
+
+def complete(measurements):
+
+    rest = dict()
+
+    rest["rho"] = measurements["np"] - measurements["nh"]
+    rest["N"]   = measurements["np"] + measurements["nh"]
+    rest["S3"]  = 0.5 * ( 1 - rest["N"])
+
+    return {**measurements, **rest}

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -58,7 +58,7 @@ class OnePointFunctions(Measurement):
     def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None), transform=None):
         r"""!
         \param particleAllToAll propagator.AllToAll for particles.
-        \param holesAllToAll propagator.AllToAll for holes.
+        \param holeAllToAll propagator.AllToAll for holes.
         \param savePath Path in the output file where results are saved.
         \param configSlice `slice` indicating which configurations to measure on.
         \param transform Transformation matrix applied to correlators in position space.

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -123,7 +123,7 @@ class measurement(Measurement):
 
 def complete(measurements):
     r"""!
-    \param measurements a dictionary of measurements, like what is returned from read().
+    \param measurements a dictionary of measurements that has measurements of `"np"` and `"nh"`
 
     Measurements of one-point functions \f$\rho_x\f$, \f$n_x\f$,
     and \f$S^3_x\f$ are built from measurements of \f$n^p_x\f$ and \f$n^h_x\f$
@@ -132,9 +132,7 @@ def complete(measurements):
     This can be used with the following example codeblock
 
     ```python
-        with h5.File('measurements.h5','r') as f:
-            data = isle.meas.onePointFunctions.read(f["correlation_functions/one_point"])
-
+        # data is a dictionary with "np" and "nh" keys that point to numpy arrays
         data = isle.meas.onePointFunctions.complete(data)
     ```
 
@@ -144,7 +142,7 @@ def complete(measurements):
     rest = dict()
 
     rest["rho"] = measurements["np"] - measurements["nh"]
-    rest["N"]   = measurements["np"] + measurements["nh"]
-    rest["S3"]  = 0.5 * ( 1 - rest["N"])
+    rest["n"]   = measurements["np"] + measurements["nh"]
+    rest["S3"]  = 0.5 * ( 1 - rest["n"])
 
     return {**measurements, **rest}

--- a/src/isle/meas/onePointFunctions.py
+++ b/src/isle/meas/onePointFunctions.py
@@ -39,6 +39,7 @@ We can transform into a different basis; by default the results are in the spati
 from logging import getLogger
 
 import numpy as np
+import h5py as h5
 
 import isle
 from .measurement import Measurement
@@ -46,6 +47,8 @@ from ..util import temporalRoller
 from ..h5io import createH5Group
 
 fields = ["np", "nh"]
+
+#TODO: save / retrieve einsum paths.
 
 class measurement(Measurement):
     r"""!
@@ -79,8 +82,6 @@ class measurement(Measurement):
         nt = P.shape[1]
 
         d = np.eye(nx*nt).reshape(*P.shape) # A Kronecker delta
-        if self.transform is None:
-            self.transform = np.eye(nx)
 
         log = getLogger(__name__)
 
@@ -88,15 +89,24 @@ class measurement(Measurement):
         data["np"] = d-P
         data["nh"] = d-H
 
-        # We'll time average and transform at once:
         if self._einsum_path is None:
-            self._einsum_path, _ = np.einsum_path("ax,xtxt->a", self.transform, data["np"], optimize="optimal")
-            log.info("Optimized Einsum path for time averaging and unitary transformation.")
+            if self.transform is None:
+                # No need for the transformation, cut the cost:
+                self._einsum_path, _ = np.einsum_path("xtxt->x", data['np'], optimize="optimal")
+                log.info("Optimized Einsum path for time averaging.")
+            else:
+                # We'll time average and transform at once:
+                self._einsum_path, _ = np.einsum_path("ax,xtxt->a", self.transform, data["np"], optimize="optimal")
+                log.info("Optimized Einsum path for time averaging and unitary transformation.")
 
-
-        for correlator in self.data:
-            measurement = np.einsum("ax,xtxt->a", self.transform, data[correlator], optimize=self._einsum_path) / nt
-            self.data[correlator].append(measurement)
+        if self.transform is None:
+            for correlator in self.data:
+                measurement = np.einsum("xtxt->x", data[correlator], optimize=self._einsum_path) / nt
+                self.data[correlator].append(measurement)
+        else:
+            for correlator in self.data:
+                measurement = np.einsum("ax,xtxt->a", self.transform, data[correlator], optimize=self._einsum_path) / nt
+                self.data[correlator].append(measurement)
 
 
     def save(self, h5group):
@@ -104,22 +114,70 @@ class measurement(Measurement):
         \param h5group Base HDF5 group. Data is stored in subgroup `h5group/self.savePath`.
         """
         subGroup = createH5Group(h5group, self.savePath)
-        subGroup["transform"] = self.transform
+        if self.transform is None:
+            subGroup["transform"] = h5.Empty(dtype="complex")
+        else:
+            subGroup["transform"] = self.transform
         for field in self.data:
             subGroup[field] = self.data[field]
 
 def read(h5group):
     r"""!
     \param h5group HDF5 group which contains the data of this measurement.
+
+    \returns A dictionary of measurements and a basis transformation, \n
+    {    \n
+        `np`: \f$n^p_x\f$,                      \n
+        `nh`: \f$n^h_x\f$,                      \n
+        `onePoint-transform`: A transformation from position space to another space \n
+        }
+    where both \f$n^{p,h}_x\f$ have the shape [measurements, spatial dimension] as long as `onePoint-transform` is square.
     """
-    return {key: h5group[key][()] for key in h5group}
+
+    try:
+        data = {key: h5group[key][()] for key in h5group}
+
+        if type(data['transform']) is h5.Empty:
+            data['transform'] = None
+
+        data['onePoint-transform'] = data['transform']
+        del data['transform']
+
+        return data
+    except:
+        raise KeyError(f"Problem reading onePointFunction measurements from {h5group.name}")
 
 def complete(measurements):
+    r"""!
+    \param measurements a dictionary of measurements, like what is returned from read().
 
-    rest = dict()
+    Measurements of one-point functions \f$\rho_x\f$, \f$n_x\f$,
+    and \f$S^3_x\f$ are built from measurements of \f$n^p_x\f$ and \f$n^h_x\f$
+    using the identities above.
 
-    rest["rho"] = measurements["np"] - measurements["nh"]
-    rest["N"]   = measurements["np"] + measurements["nh"]
-    rest["S3"]  = 0.5 * ( 1 - rest["N"])
+    This can be used with the following example codeblock
 
-    return {**measurements, **rest}
+    ```python
+        with h5.File('measurements.h5','r') as f:
+            data = isle.meas.onePointFunctions.read(f["correlation_functions/one_point"])
+
+        data = isle.meas.onePointFunctions.complete(data)
+    ```
+
+    \returns a dictionary with additional one-point functions, built from those already computed.
+    """
+
+    try:
+        rest = dict()
+
+        rest["rho"] = measurements["np"] - measurements["nh"]
+        rest["N"]   = measurements["np"] + measurements["nh"]
+        rest["S3"]  = 0.5 * ( 1 - rest["N"])
+
+        return {**measurements, **rest}
+
+    except KeyError:
+        raise KeyError(f"Needed fields np, nh are not both available in {measurements.keys()}")
+
+    except ValueError:
+        raise ValueError("Particle and hole one-point measurements are incompatible shapes, {measurements['np'].shape} and {measurements['nh'].shape}, respectively.")

--- a/src/isle/meas/singleParticleCorrelator.py
+++ b/src/isle/meas/singleParticleCorrelator.py
@@ -1,6 +1,65 @@
 r"""!\file
 \ingroup meas
-Measurement of single-particle correlator.
+
+# Single-Particle and -Hole operators
+
+On each site we have four ladder operators, the particle destruction and creation
+operators, \f$a\f$ and \f$a^\dagger\f$, and the hole operators \f$b\f$, \f$b^\dagger\f$.
+
+Particles also have z-component of spin \f$-\frac{1}{2}\f$ because
+\f$[S^3_x, a_y^\dagger] = -\frac{1}{2} a_y^\dagger \delta_{xy}\f$
+ and charge \f$+1\f$ because
+\f$[\rho_x, a_y^\dagger] = +1 a_y^\dagger \delta_{xy}\f$
+(see spinSpinCorrelator.py for more details).
+Similarly, holes have z-component of spin \f$-\frac{1}{2}\f$ (the same sign as particles!)
+but charge \f$-1\f$.
+
+We can therefore construct operators that create a definite charge but indefinite spin, and vice-versa,
+\f{align}{
+    q^+_x &= \frac{a_x^\dagger + b_x}{\sqrt{2}}
+    &
+    q^-_x &= \frac{a_x + b_x^\dagger}{\sqrt{2}}
+    \\
+    s^+_x &= \frac{a_x + b_x}{\sqrt{2}}
+    &
+    s^-_x &= \frac{a_x^\dagger + b_x^\dagger}{\sqrt{2}}
+\f}
+so that \f$[\rho_x, q^\pm_y] = \pm 1           q^\pm_y \delta_{xy}\f$
+and     \f$[S^3_x,  s^\pm_y] = \pm \frac{1}{2} s^\pm_y \delta_{xy}\f$
+but these guys have indefinite (spin/charge, respectively) quantum number, and therefore mix
+under Hamiltonian evoluation.  Diagonalizing would reveal the particle/hole sectors
+already discussed, so we do not construct correlation functions with these operators,
+or any other linear combinations (there are plenty).
+
+# Correlation functions
+
+Now we can write correlation functions
+\f[
+    C^{ij}_{xy}(\tau) = \frac{1}{N_t} \sum_t \left\langle i_{x,t+\tau} j_{y,t} \right\rangle
+\f]
+and we suppress the time dependence for the time being.
+
+We can perform contractions,
+\f{align}{
+    C^{a a^\dagger}_{xy}(\tau)  &   = \left\langle a_{x} a_{y}^\dagger \right\rangle
+                                    = \left\langle P_{xy} \right\rangle
+                            &
+    C^{a^\dagger a}_{xy}(\tau)  &   = \left\langle a_x^\dagger a_y \right\rangle
+                                    = \left\langle \delta_{yx} - a_y a_x^\dagger \right\rangle
+                                    = \left\langle \delta_{yx} - P_{yx} \right\rangle
+                            \\
+    C^{b b^\dagger}_{xy}(\tau)  &   = \left\langle b_{x} b_{y}^\dagger \right\rangle
+                                    = \left\langle H_{xy} \right\rangle
+                            &
+    C^{b^\dagger b}_{xy}(\tau)  &   = \left\langle b_x^\dagger b_y \right\rangle
+                                    = \left\langle \delta_{yx} - b_y b_x^\dagger \right\rangle
+                                    = \left\langle \delta_{yx} - H_{yx} \right\rangle
+\f}
+and because of the identity \f$\{a_x,a_y^\dagger\} = \delta_{xy}\f$ one can show that
+in expectation value \f$C^{a a^\dagger}_{xy}(\tau) = C^{a^\dagger a}_{yx}(-\tau)\f$
+and likewise for holes.  Note that this is true in expectation value and not
+configuration-by-configuration.  Therefore it is worthwhile to perform both measurements.
+
 """
 
 import numpy as np
@@ -11,64 +70,106 @@ from ..util import spaceToSpacetime, temporalRoller
 from ..h5io import createH5Group
 from .propagator import AllToAll
 
+
+def _checkCorrNames(actual, allowed):
+    for name in actual:
+        if name not in allowed:
+            raise ValueError(f"Unknown correlator: '{name}'. Choose from '{allowed}'")
+
 class SingleParticleCorrelator(Measurement):
     r"""!
     \ingroup meas
     Tabulate single-particle correlator.
     """
 
-    def __init__(self, allToAll, savePath, configSlice=slice(None, None, None), projector=None):
+    CORRELATOR_NAMES = {"creation_destruction", "destruction_creation"}
+
+    def __init__(self, allToAll, savePath, configSlice=slice(None, None, None),
+                 transform=None, correlators=CORRELATOR_NAMES):
+        r"""!
+        \param allToAll propagator.AllToAll for one species.
+        \param savePath Path in the output file where results are saved.
+        \param configSlice `slice` indicating which configurations to measure on.
+        \param transform   Transformation matrix applied to correlators in position space.
+        \param correlators Iterable of names of correlators to compute.
+                           Defaults to `SingleParticleCorrelator.CORRELATOR_NAMES`.
+        """
         super().__init__(savePath, configSlice)
 
-        self.correlators = []
+        _checkCorrNames(correlators, self.CORRELATOR_NAMES)
+
+        # The correlation functions encoded here are between single ladder operators.
+        self.fermionic = True
+
         self._inverter = allToAll
-        self._path = None
-        self._indices = "idf,bx,xfyi,ya->bad"
-        self._roll = None
 
-        self.nx = self._inverter.nx
-        self.nt = None
+        self.correlators = {c: [] for c in correlators}
+        self._path = {c: None for c in correlators}
 
-        if projector is None:
-            _, self.irreps = np.linalg.eigh(isle.Matrix(allToAll.hfm.kappaTilde()))
-            self.irreps = self.irreps
+        self.transform = transform
+        self._indices = dict()
+        if self.transform is None:
+            self._indices["creation_destruction"] = "idf,yixf->xyd"
+            self._indices["destruction_creation"] = "idf,xfyi->xyd"
         else:
-            self.irreps = projector
+            self._indices["creation_destruction"] = "idf,bx,yixf,ya->bad"
+            self._indices["destruction_creation"] = "idf,bx,xfyi,ya->bad"
+
+        self._einsum_paths = {c: None for c in self.correlators}
+
+        self._roll = None
 
     def __call__(self, stage, itr):
         """!Record the single-particle correlators."""
 
         S = self._inverter(stage, itr)
+        nx = S.shape[0]
+        nt = S.shape[1]
 
-        if self.nt is None:
-            self.nt = len(stage.phi) // self.nx
+        d = np.eye(nx*nt).reshape(*S.shape) # A kronecker delta
+
         if self._roll is None:
-            self._roll = np.array([temporalRoller(self.nt, -t) for t in range(self.nt)])
+            self._roll = np.array([temporalRoller(nt, -t, fermionic=self.fermionic) for t in range(nt)])
 
-        self._tensors = (self._roll, self.irreps.T.conj(), S, self.irreps)
+        # If there's no transformation needed, we should avoid doing
+        # space matrix-matrix-matrix, as it will scale poorly.
+        tensors = dict()
+        if self.transform is None:
+            tensors['destruction_creation'] = (self._roll, S)
+            tensors['creation_destruction'] = (self._roll, d-S)
+        else:
+            tensors['destruction_creation'] = (self._roll, self.transform.T.conj(), S, self.transform)
+            tensors['creation_destruction'] = (self._roll, self.transform.T.conj(), d-S, self.transform)
 
-        if self._path is None:
-            self._path, _ = np.einsum_path(self._indices, *self._tensors, optimize='optimal')
+        for c in self.correlators:
+            if self._einsum_paths[c] is None:
+                self._einsum_paths[c], _ = np.einsum_path(self._indices[c], *tensors[c], optimize='optimal')
 
         # The temporal roller sums over time, but does not *average* over time.  So, divide by nt:
-        correlator = np.einsum(self._indices, *self._tensors, optimize=self._path) / self.nt
-
-        # Done!
-        self.correlators.append(correlator)
+        for name, correlator in self.correlators.items():
+            self.correlators[name].append(np.einsum(self._indices[name],
+                                                   *tensors[name],
+                                                    optimize=self._einsum_paths[name]) / nt)
 
     def save(self, h5group):
         r"""!
-        Write the irreps and their correlators to a file.
+        Write the transformation and correlators to a file.
         \param h5group Base HDF5 group. Data is stored in subgroup `h5group/self.savePath`.
         """
         subGroup = createH5Group(h5group, self.savePath)
-        subGroup["correlators"] = self.correlators
-        subGroup["irreps"] = self.irreps
+
+        for name, correlator in self.correlators.items():
+            subGroup[name] = correlator
+
+        if self.transform is None:
+            subGroup["transform"] = h5.Empty(dtype="complex")
+        else:
+            subGroup["transform"] = self.transform
         # subGroup["einsum_path"] = self._path # TODO: store the optimization; this line of code doesn't work.
 
 def read(h5group):
     r"""!
-    Read the irreps and their correlators from a file.
+    Read the transform and their correlators from a file.
     \param h5group HDF5 group which contains the data of this measurement.
     """
-    return h5group["correlators"][()], h5group["irreps"][()]
+    return h5group["correlators"][()], h5group["transform"][()]

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -397,9 +397,7 @@ Because we do not assume a bipartite graph, we implement Meng and Wessel's \f$S_
 from logging import getLogger
 
 import numpy as np
-import h5py as h5
 
-import isle
 from .measurement import Measurement
 from ..util import temporalRoller, signAlternator
 from ..h5io import createH5Group

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -403,7 +403,7 @@ from .measurement import Measurement
 from ..util import temporalRoller, signAlternator
 from ..h5io import createH5Group
 
-class SpinSpinCorrelator(Measurement):
+class measurement(Measurement):
     r"""!
     \ingroup meas
     Tabulate spin-spin correlators.
@@ -598,8 +598,32 @@ class SpinSpinCorrelator(Measurement):
             subGroup[field] = self.data[field]
 
 
-def read(h5group):
-    r"""!
-    \param h5group HDF5 group which contains the data of this measurement.
-    """
-    ...
+def complete(measurements, correlators=["S1_S1", "S1_S2", "rho_rho", "rho_n", "n_rho", "n_n",
+                                    "S3_S3", "S3_S0", "S0_S3", "S0_S0"
+                                    ], onePoint=None):
+
+    requiresOnePoint = ["S3_S3", "S3_S0", "S0_S3", "S0_S0"]
+
+    rest = dict()
+
+    if "S1_S1" in correlators:
+        rest["S1_S1"]   = 0.25 *(measurements["Splus_Sminus"] + measurements["Sminus_Splus"])
+    if "S1_S2" in correlators:
+        rest["S1_S2"]   = 0.25j*(time_averaged["Splus_Sminus"] - measurements["Sminus_Splus"])
+    if "rho_rho" in correlators:
+        rest["rho_rho"] = measurements["np_np"] + measurements["nh_nh"] - measurements["np_nh"] - measurements["nh_np"]
+    if "rho_n" in correlators:
+        rest["rho_n"]   = measurements["np_np"] - measurements["nh_nh"] + measurements["np_nh"] - measurements["nh_np"]
+    if "n_rho" in correlators:
+        rest["n_rho"]   = measurements["np_np"] - measurements["nh_nh"] - measurements["np_nh"] + measurements["nh_np"]
+    if "n_n" in correlators:
+        rest["n_n"]     = measurements["np_np"] + measurements["nh_nh"] + measurements["np_nh"] + measurements["nh_np"]
+
+    if onePoint is None:
+        log = getLogger(__name__)
+        log.info(f"No one point measurements were provided; will not compute {requiresOnePoint} correlators.")
+        return {**measurements, **rest}
+
+    # if "S3_S3" in correlators:
+    #     rest["S3_S3"] =
+    return {**measurements, **rest}

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -605,7 +605,7 @@ class measurement(Measurement):
             subGroup[field] = self.data[field]
 
 
-def complete(measurements):
+def useIdentities(measurements):
     r"""!
     \param measurements a dictionary of measurements that has measurements of `"Splus_Sminus"`,
     `"Sminus_Splus"`, `"np_np"`, `"np_nh"`, `"nh_np"`, and `"nh_nh"` (and other fields are allowed).

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -410,7 +410,7 @@ fields = (
     '++_--', '--_++',
 )
 
-class spinSpinCorrelator(Measurement):
+class SpinSpinCorrelator(Measurement):
     r"""!
     \ingroup meas
     Tabulate spin-spin correlators.

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -410,7 +410,7 @@ fields = (
     '++_--', '--_++',
 )
 
-class measurement(Measurement):
+class spinSpinCorrelator(Measurement):
     r"""!
     \ingroup meas
     Tabulate spin-spin correlators.
@@ -605,7 +605,7 @@ class measurement(Measurement):
             subGroup[field] = self.data[field]
 
 
-def useIdentities(measurements):
+def computeDerivedCorrelators(measurements):
     r"""!
     \param measurements a dictionary of measurements that has measurements of `"Splus_Sminus"`,
     `"Sminus_Splus"`, `"np_np"`, `"np_nh"`, `"nh_np"`, and `"nh_nh"` (and other fields are allowed).

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -25,9 +25,10 @@ Rewriting those operators into the Isle basis,
     S^0_x &= \frac{1}{2} \left[ a_x a_x^\dagger – b_x b_x^\dagger +1 \right]                    \\
     S^1_x &= \frac{1}{2} (–\sigma_\kappa)^x \left[ b_x^\dagger a_x^\dagger + a_x b_x \right]    \\
     S^2_x &= \frac{i}{2} (–\sigma_\kappa)^x \left[ b_x^\dagger a_x^\dagger – a_x b_x \right]    \\
-    S^3_x &= \frac{1}{2} \left[ a_x a_x^\dagger + b_x b_x^\dagger –1 \right]
+    S^3_x &= \frac{1}{2} \left[ a_x a_x^\dagger + b_x b_x^\dagger –1 \right]                    \\
+    n_x   &= a_x^\dagger a_x + b_x^\dagger b_x
 \f}
-where the \f$\sigma_\kappa\f$ squares away when two \f$b\f$ operators are multiplied.
+where the \f$\sigma_\kappa\f$ squares away when two \f$b\f$ operators are multiplied and we introduce the total-number operator \f$n\f$ with no superscript.
 Note the operator ordering in \f$\rho\f$ is opposite from \f$S^0\f$, and that particles are positively charged.
 
 The three spin operators obey the commutation relation
@@ -84,20 +85,40 @@ which obey the eigenvalue relations
 \f]
 which can be shown using the single-particle and single-hole eigenvalue equations and the identity \f$[A, BC] = [A,B]C + B[A,C]\f$.
 
-Something I have not seen elsewhere is the construction of the number operators in a similar fashion,
+The construction of the number operators can be done in a similar fashion,
 \f{align}{
-    \delta_{xx} – N^p_x &= S^0_x + S^3_x = a_x a^\dagger_x = \delta_{xx} – a^\dagger_x a_x
+    \delta_{xx} – n^p_x &= S^0_x + S^3_x = a_x a^\dagger_x = \delta_{xx} – a^\dagger_x a_x
     \\
-    N^h_x &= S^0_x – S^3_x = –b_x b^\dagger_x + \delta_{xx} = –\delta_{xx} + b^\dagger_x b_x + \delta_{xx} = b^\dagger_x b_x.
+    n^h_x &= S^0_x – S^3_x = –b_x b^\dagger_x + \delta_{xx} = –\delta_{xx} + b^\dagger_x b_x + \delta_{xx} = b^\dagger_x b_x.
 \f}
 We can of course drop the constant term in the first definition.
+We use the shorthand
+\f{align}{
+    n_x &= n^p_x + n^h_x = \delta_{xx}-2 S^3_x
+    \\
+    \text{as in }
+    \rho_x &= n^p_x - n^h_x = \delta_{xx}-2 S^0_x
+\f}
 
+## Charge ≠ 0
+
+All the above bilinears have charge zero, since \f$[\rho,\cdot]=0\f$.
+However, there are two bilinears that are missing from the above operators, and they have nonzero charge.
+(To get a charge of 1, one must have an odd number of particle and hole operators.)
+The two operators are \f$a^\dagger b\f$ and \f$b^\dagger a\f$ with charge ±2,
+\f{align}{
+    [\rho_x, a_y^\dagger b_y] = &+ 2 \delta_{xy} a_y^\dagger b_y \\
+    [\rho_x, b_y^\dagger a_y] = &– 2 \delta_{xy} b_y^\dagger a_y.
+\f}
+which we'll indicate with double symbols, \f${}^+_+\f$ and \f${}^-_-\f$, respectively.
+As they are charged, these are best interpreted as creation and annihilation operators.
+It is easy to check that these operators have \f$[S^z,\cdot]=0\f$.
 
 # Correlation Functions
 
 Now we can write correlation functions
 \f[
-    C^{ij}_{xy}(\tau) = \frac{1}{N_t} \sum_t \left\langle S^{i}_{x,t+\tau} S^{j}_{y,t}{}^\dagger \right\rangle
+    C^{ij}_{xy}(\tau) = \frac{1}{N_t} \sum_t \left\langle S^{i}_{x,t+\tau} S^{j}_{y,t} \right\rangle
 \f]
 and we don't need to track time separately, until we start analyzing how to actually use this correlation function.
 
@@ -138,7 +159,7 @@ and what we get by exchanging particles with holes,
     C^{hh}_{xy}     = \left\langle N^p_x N^p_y \right\rangle
                 &   = \left\langle \delta_{xx}\delta_{yy} - \delta_{xx} H_{yy} - H_{xx} \delta_{yy} + \delta_{yx} H_{xy} – H_{xy} H_{yx} + H_{xx} H_{yy}  \right\rangle
 \f}
-though these are more complicated to _compute_ because they have so-called disconnected diagrams.
+though these are more complicated to _compute_ because they have so-called disconnected diagrams.  However, with all-to-all propagators, it's all the same.
 
 We can build correlations between the spin operators themselves.
 For example,
@@ -168,8 +189,9 @@ so that
 \f[
     C^{11}_{xy} = C^{22}_{xy}
     =
-    \frac{1}{4}\left(C^{+–}_{xy}+C^{–+}_{xy}\right)
+    \frac{1}{4}\left(C^{+–}_{xy}+C^{–+}_{xy}\right),
 \f]
+which you can directly verify with the explict contractions above.
 Similarly, knowing that the four-dagger and no-dagger terms vanish, it is easy to show
 \f[
          \left\langle S^{1}_{x}S^{2}_y\right\rangle
@@ -218,15 +240,38 @@ We are stuck computing four correlators and taking advantage of the one-point fu
         \right)
         \\
     \text{and we define }
-    C^{\rho\rho}_{xy} &= C^{pp}_{xy} + C^{hh}_{xy} - C^{ph}_{xy} - C^{hp}_{xy}
+    C^{\rho\rho}_{xy} &= C^{pp}_{xy} + C^{hh}_{xy} - C^{ph}_{xy} - C^{hp}_{xy},
+        \\
+    C^{\rho n}_{xy}   &= C^{pp}_{xy} - C^{hh}_{xy} + C^{ph}_{xy} - C^{hp}_{xy},
+        \\
+    C^{n \rho}_{xy}   &= C^{pp}_{xy} - C^{hh}_{xy} - C^{ph}_{xy} + C^{hp}_{xy},
+        \\
+    \text{and }
+    C^{nn}_{xy} &= C^{pp}_{xy} + C^{hh}_{xy} + C^{ph}_{xy} + C^{hp}_{xy}
 \f}
-the correlator between two charge density operators \f$C^{\rho\rho}_{xy}=\left\langle\rho_x\rho_y\right\rangle\f$.
-(In the above relations that require one-point functions 1 indicates a matrix full of ones---not an identity matrix in x and y.  Similarly \f$N_x\f$ changes in x but is constant in y, and vice-versa for \f$N_y\f$.)
+so that the correlator between two charge density operators \f$C^{\rho\rho}_{xy}=\left\langle\rho_x\rho_y\right\rangle\f$ and
+the correlator between two total-number operators \f$C^{nn}_{xy} = \left\langle  n_x n_y\right\rangle\f$ where \f$n\f$ counts both particles and holes.
+(In the first four above relations that require one-point functions 1 indicates a matrix full of ones---not an identity matrix in x and y.  Similarly \f$N_x\f$ changes in x but is constant in y, and vice-versa for \f$N_y\f$.)
 
 Note that 1 and 2 cannot mix with 0 or 3 because each term would not have the right constituent operator content to contract completely.  This is very curious.
 I think if we had a spin chemical potential that mixed \f$a\f$ and \f$b\f$ operators, such as \f$\mu S^1\f$, we would not be able to split the operators into two species, because the bilinear piece would allow one species to mix with the other while propagating,
 so that the contractions, rather than considering \f$a\f$ and \f$b\f$ separately, would consider \f$c\f$ operators with more entries and the chemical potential would introduce an off-diagonal component.
 Working out the details of this is a question for a different time, however.
+
+The charge +2 and –2 operators cannot be contracted with any of the other bilinears, by conservation of charge.
+However, they can be contracted with each other.
+\f{align}{
+    C^{{}^+_+{}^-_-} = \left\langle a_x^\dagger b_x b_y^\dagger a_y \right\rangle
+                    &= \left\langle a_x^\dagger a_y b_x b_y^\dagger \right\rangle                   \\
+                    &= \left\langle (\delta_{yx} - a_y a_x^\dagger) b_x b_y^\dagger \right\rangle   \\
+                    &= \left\langle (\delta_{yx} - P_{yx}) H_{xy} \right\rangle                         \\
+                    \\
+    C^{{}^-_-{}^+_+} = \left\langle b_x^\dagger a_x a_y^\dagger b_y\right\rangle
+                    &= \left\langle b_x^\dagger b_y a_x a_y^\dagger \right\rangle                   \\
+                    &= \left\langle (\delta_{yx} - b_y b_x^\dagger) a_x a_y^\dagger \right\rangle   \\
+                    &= \left\langle (\delta_{yx} - H_{yx}) P_{xy} \right\rangle;                        \\
+\f}
+recall that the double-plus operator and double-minus operator are Hermitian conjugates.
 
 
 # Conserved Quantities
@@ -355,7 +400,7 @@ import numpy as np
 
 import isle
 from .measurement import Measurement
-from ..util import temporalRoller
+from ..util import temporalRoller, signAlternator
 from ..h5io import createH5Group
 
 class SpinSpinCorrelator(Measurement):
@@ -364,7 +409,7 @@ class SpinSpinCorrelator(Measurement):
     Tabulate spin-spin correlators.
     """
 
-    def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None), projector=None, sigmaKappa=-1):
+    def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None), transform=None, sigmaKappa=-1):
         super().__init__(savePath, configSlice)
 
         # The correlation functions encoded here are between bilinear operators.
@@ -377,14 +422,17 @@ class SpinSpinCorrelator(Measurement):
         self.particle=particleAllToAll
         self.hole=holeAllToAll
 
-        self.data = {k: [] for k in ["rho_rho", "S1_S1", "S3_S3", "Splus_Sminus", "Sminus_Splus", "Np_Nh", "Nh_Np", "Np_Np", "Nh_Nh", "Q2S0_Q2S0"]}
+        self.data = {k: [] for k in [
+            # Directly computed
+            "Splus_Sminus", "Sminus_Splus",
+            "np_np", "np_nh", "nh_np", "nh_nh",
+            "++_--", "--_++",
+            # And their combinations:
+            "S1_S1", "S1_S2",
+            "rho_rho", "rho_n", "n_rho", "n_n"
+            ]}
 
-        if projector is None:
-            # TODO: warn when diagonalizing the hopping matrix.
-            _, self.irreps = np.linalg.eigh(isle.Matrix(allToAll.hfm.kappaTilde()))
-            self.irreps = self.irreps
-        else:
-            self.irreps = projector
+        self.transform = transform
 
         self._einsum_paths = {}
 
@@ -397,98 +445,155 @@ class SpinSpinCorrelator(Measurement):
         nx = P.shape[0]
         nt = P.shape[1]
 
+        # This puts in all needed factors of (-sigmaKappa)^{x+y}!
+        # For operators which DON'T need it, it does nothing---the reason
+        # those operators don't need it is that the sign squares away.
+        if self.sigmaKappa == +1:
+            # This could be done without a test on sigmaKappa, since signAlternator
+            # returns the identity matrix if sigmaKappa is -1, but then we'd be doing
+            # 1-matrix-1 multiplication for no reason, and it's not cheap.
+            Sigma = signAlternator(nx, self.sigmaKappa)
+            P = np.einsum('ax,xfyi,yb->afyb', Sigma, P, Sigma, optimize="optimal")
+            H = np.einsum('ax,xfyi,yb->afyb', Sigma, H, Sigma, optimize="optimal")
+
+
         d = np.eye(nx*nt).reshape(*P.shape) # A Kronecker delta
 
         log = getLogger(__name__)
+
         # TODO: store some einsum paths
+
+        # Contractions always result in a tensor xfyi, where xf are space/time at the sink
+        # and yi are space/time at the source.  Because we have to move all the daggers to the right
+        # to Wick contract ladder operators into propagators, however, the indices on the propagators
+        # need not be in the same order.
+
+        # Contractions are grouped into 4 categories,
+        #   xfxf,yiyi->xfyi
+        #   xfyi,xfyi->xfyi
+        #   xfyi,yixf->xfyi
+        #   yixf,yixf->xfyi
+        #
+        # Note that other orders are all ready covered
+        #   yixf,xfyi = xfyi,yixf
+        #   yiyi,xfxf = xfxf,yiyi
+        #
+        # Even in those four categories, there may be enormous redundencies.
+        # For example, the kronecker delta is symmetric.
         if "xfxf,yiyi->xfyi" not in self._einsum_paths:
             self._einsum_paths["xfxf,yiyi->xfyi"], _ = np.einsum_path("xfxf,yiyi->xfyi", d, d, optimize="optimal")
             log.info("Optimized Einsum path xfxf,yiyi->xfyi")
+
+        dxxdyy = np.einsum("xfxf,yiyi->xfyi", d, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+        dxxPyy = np.einsum("xfxf,yiyi->xfyi", d, P, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+        dxxHyy = np.einsum("xfxf,yiyi->xfyi", d, H, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+        Pxxdyy = np.einsum("xfxf,yiyi->xfyi", P, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
         PxxPyy = np.einsum("xfxf,yiyi->xfyi", P, P, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
         PxxHyy = np.einsum("xfxf,yiyi->xfyi", P, H, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
-        dxxdyy = np.einsum("xfxf,yiyi->xfyi", d, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+        Hxxdyy = np.einsum("xfxf,yiyi->xfyi", H, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
         HxxPyy = np.einsum("xfxf,yiyi->xfyi", H, P, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
         HxxHyy = np.einsum("xfxf,yiyi->xfyi", H, H, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+
+        if "xfyi,xfyi->xfyi" not in self._einsum_paths:
+            self._einsum_paths["xfyi,xfyi->xfyi"], _ = np.einsum_path("xfyi,xfyi->xfyi", d, d, optimize="optimal")
+            log.info("Optimized Einsum path xfyi,xfyi->xfyi")
+
+    #   dxydxy = dyxdyx
+    #   dxyPxy = Pxydxy
+    #   dxyHxy = Hxydyx
+    #   Pxydxy = Pxydyx
+    #   PxyPxy cannot appear by Pauli exclusion
+        PxyHxy = np.einsum("xfyi,xfyi->xfyi", P, H, optimize=self._einsum_paths["xfyi,xfyi->xfyi"])
+    #   Hxydxy = Hxydyx
+    #   HxyPxy = PxyHxy
+    #   HxyHxy cannot appear by Pauli exclusion
 
         if "xfyi,yixf->xfyi" not in self._einsum_paths:
             self._einsum_paths["xfyi,yixf->xfyi"], _ = np.einsum_path("xfyi,yixf->xfyi", d, d, optimize="optimal")
             log.info("Optimized Einsum path xfyi,yixf->xfyi")
 
-        PxyPyx = np.einsum("xfyi,yixf->xfyi", P, P, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
+    #   dxydyx = dyxdyx
+    #   dxyPyx = Pyxdyx
+    #   dxyHyx = Hyxdyx
         Pxydyx = np.einsum("xfyi,yixf->xfyi", P, d, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
+        PxyPyx = np.einsum("xfyi,yixf->xfyi", P, P, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
+        PxyHyx = np.einsum("xfyi,yixf->xfyi", P, H, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
         Hxydyx = np.einsum("xfyi,yixf->xfyi", H, d, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
+        HxyPyx = np.einsum("xfyi,yixf->xfyi", H, P, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
         HxyHyx = np.einsum("xfyi,yixf->xfyi", H, H, optimize=self._einsum_paths["xfyi,yixf->xfyi"])
 
         if "yixf,yixf->xfyi" not in self._einsum_paths:
             self._einsum_paths["yixf,yixf->xfyi"], _ = np.einsum_path("yixf,yixf->xfyi", d, d, optimize="optimal")
             log.info("Optimized Einsum path yixf,yixf->xfyi")
 
-        PyxHyx = np.einsum("yixf,yixf->xfyi", P, H, optimize=self._einsum_paths["yixf,yixf->xfyi"])
-        Pyxdyx = np.einsum("yixf,yixf->xfyi", P, d, optimize=self._einsum_paths["yixf,yixf->xfyi"])
-        Hyxdyx = np.einsum("yixf,yixf->xfyi", H, d, optimize=self._einsum_paths["yixf,yixf->xfyi"])
         dyxdyx = np.einsum("yixf,yixf->xfyi", d, d, optimize=self._einsum_paths["yixf,yixf->xfyi"])
-
-        if "yixf,xfyi->xfyi" not in self._einsum_paths:
-            self._einsum_paths["yixf,xfyi->xfyi"], _ = np.einsum_path("yixf,xfyi->xfyi", d, d, optimize="optimal")
-            log.info("Optimized yixf,xfyi->xfyi")
-
-        PyxHxy = np.einsum("yixf,xfyi->xfyi", P, H, optimize=self._einsum_paths["yixf,xfyi->xfyi"])
-
-        if "xfyi,xfyi->xfyi" not in self._einsum_paths:
-            self._einsum_paths["xfyi,xfyi->xfyi"], _ = np.einsum_path("xfyi,xfyi->xfyi", d, d, optimize="optimal")
-            log.info("Optimized Einsum path xfyi,xfyi->xfyi")
-
-        PxyHxy = np.einsum("xfyi,xfyi->xfyi", P, H, optimize=self._einsum_paths["xfyi,xfyi->xfyi"])
-        Pxydyx = np.einsum("xfyi,xfyi->xfyi", P, d, optimize=self._einsum_paths["xfyi,xfyi->xfyi"])
-        Hxydyx = np.einsum("xfyi,xfyi->xfyi", H, d, optimize=self._einsum_paths["xfyi,xfyi->xfyi"])
-
-        if "xfxf,yiyi->xfyi" not in self._einsum_paths:
-            self._einsum_paths["xfxf,yiyi->xfyi"], _ = np.einsum_path("xfxf,yiyi->xfyi", d, d, optimize="optimal")
-            log.info("Optimized Einsum path xfxf,yiyi->xfyi")
-
-        Pxxdyy = np.einsum("xfxf,yiyi->xfyi", P, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
-        dxxPyy = np.einsum("xfxf,yiyi->xfyi", d, P, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
-        Hxxdyy = np.einsum("xfxf,yiyi->xfyi", H, d, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
-        dxxHyy = np.einsum("xfxf,yiyi->xfyi", d, H, optimize=self._einsum_paths["xfxf,yiyi->xfyi"])
+    #   dyxPyx = Pyxdyx
+    #   dyxHyx = Hyxdyx
+        Pyxdyx = np.einsum("yixf,yixf->xfyi", P, d, optimize=self._einsum_paths["yixf,yixf->xfyi"])
+    #   PyxPyx cannot appear by Pauli exclusion.
+        PyxHyx = np.einsum("yixf,yixf->xfyi", P, H, optimize=self._einsum_paths["yixf,yixf->xfyi"])
+        Hyxdyx = np.einsum("yixf,yixf->xfyi", H, d, optimize=self._einsum_paths["yixf,yixf->xfyi"])
+    #   HyxPyx = PyxHyx
+    #   HyxHyx cannot appear by Pauli exclusion.
 
         data = dict()
-        data["rho_rho"] = (PxxPyy + HxxHyy) - (PxyPyx + HxyHyx) + (Pxydyx + Hxydyx) - (PxxHyy+HxxPyy)
-        data["S1_S1"] = 0.25*(PxyHxy+ dyxdyx - Pyxdyx - Hyxdyx + PyxHyx)
-        data["S3_S3"] = 0.25*((PxxPyy + HxxHyy) - (PxyPyx + HxyHyx) + (PxxHyy + HxxPyy) + (Pxydyx+Hxydyx) - (Pxxdyy+Hxxdyy) - (dxxPyy+dxxHyy) + dxxdyy)
+
         data["Splus_Sminus"] = PxyHxy
-        data["Sminus_Splus"] = (dyxdyx - Pyxdyx - Hyxdyx + PyxHyx)
-        data["Np_Nh"] = PxxHyy
-        data["Nh_Np"] = HxxPyy
-        data["Np_Np"] = Pxydyx + PxxPyy - PxyPyx
-        data["Nh_Nh"] = Hxydyx + HxxHyy - HxyHyx
-        data["Q2S0_Q2S0"] = 2*(Hxydyx-PyxHxy)
+        data["Sminus_Splus"] = dyxdyx - Pyxdyx - Hyxdyx + PyxHyx
+
+        data["np_nh"] = dxxdyy - Pxxdyy - dxxHyy + PxxHyy
+        data["np_np"] = dxxdyy - dxxPyy - Pxxdyy + Pxydyx - PxyPyx + PxxPyy
+        data["nh_np"] = dxxdyy - Hxxdyy - dxxPyy + HxxPyy
+        data["nh_nh"] = dxxdyy - dxxHyy - Hxxdyy + Hxydyx - HxyHyx + HxxHyy
+
+        data["++_--"] = Hxydyx - HxyPyx
+        data["--_++"] = Pxydyx - PxyHyx
 
         self._roll = np.array([temporalRoller(nt, -t, fermionic=self.fermionic) for t in range(nt)])
 
+        time_averaged = dict()
+        for correlator in data:
+
+            # It is major savings to avoid two matrix-matrix multiplies, so it is
+            # worthwhile to test for a transform and only add those multiplies in if needed.
+            if self.transform is not None:
+                if "idf,bx,xfyi,ya->bad" not in self._einsum_paths:
+                    self._einsum_paths["idf,bx,xfyi,ya->bad"], _ = np.einsum_path("idf,bx,xfyi,ya->bad", self._roll, self.transform.T.conj(), data[correlator], self.transform, optimize="optimal")
+                    log.info("Optimized Einsum path for time averaging and transform application.")
+
+                time_averaged[correlator] = np.einsum("idf,bx,xfyi,ya->bad",
+                                    self._roll,
+                                    self.transform.T.conj(),
+                                    data[correlator],
+                                    self.transform,
+                                    optimize=self._einsum_paths["idf,bx,xfyi,ya->bad"]) / nt
+            else:
+                if "idf,xfyi->xyd" not in self._einsum_paths:
+                    self._einsum_paths["idf,xfyi->xyd"], _ = np.einsum_path("idf,xfyi->xyd", self._roll, data[correlator], optimize="optimal")
+                    log.info("Optimized Einsum path for time averaging in position space.")
+
+                time_averaged[correlator] = np.einsum("idf,xfyi->xyd",
+                                    self._roll,
+                                    data[correlator],
+                                    optimize=self._einsum_paths["idf,bx,xfyi,ya->bad"]) / nt
+
+        # Now we can use identites demonstrated above to build other two-point functions:
+        time_averaged["S1_S1"] = 0.25 *(time_averaged["Splus_Sminus"] + time_averaged["Sminus_Splus"])
+        time_averaged["S1_S2"] = 0.25j*(time_averaged["Splus_Sminus"] - time_averaged["Sminus_Splus"])
+        time_averaged["rho_rho"] = time_averaged["np_np"] + time_averaged["nh_nh"] - time_averaged["np_nh"] - time_averaged["nh_np"]
+        time_averaged["rho_n"]   = time_averaged["np_np"] - time_averaged["nh_nh"] + time_averaged["np_nh"] - time_averaged["nh_np"]
+        time_averaged["n_rho"]   = time_averaged["np_np"] - time_averaged["nh_nh"] - time_averaged["np_nh"] + time_averaged["nh_np"]
+        time_averaged["n_n"]     = time_averaged["np_np"] + time_averaged["nh_nh"] + time_averaged["np_nh"] + time_averaged["nh_np"]
+
         for correlator in self.data:
-
-            # print(f"Time averaging {name}...")
-            # Just leave with spatial indices:
-            # time_averaged = np.einsum("idf,xfyi->xyd", self._roll, observable) / nt
-
-            # Project to irreps:
-            if "idf,bx,xfyi,ya->bad" not in self._einsum_paths:
-                self._einsum_paths["idf,bx,xfyi,ya->bad"], _ = np.einsum_path("idf,bx,xfyi,ya->bad", self._roll, self.irreps, data[correlator], self.irreps.conj().T, optimize="optimal")
-                log.info("Optimized Einsum path for time averaging and irrep projection.")
-
-            time_averaged = np.einsum("idf,bx,xfyi,ya->bad", self._roll, self.irreps.T.conj(),
-                                      data[correlator], self.irreps,
-                                      optimize=self._einsum_paths["idf,bx,xfyi,ya->bad"]) / nt
-
-            self.data[correlator].append(time_averaged)
-
+            self.data[correlator].append(time_averaged[correlator])
 
     def save(self, h5group):
         r"""!
         \param h5group Base HDF5 group. Data is stored in subgroup `h5group/self.savePath`.
         """
         subGroup = createH5Group(h5group, self.savePath)
-        subGroup["irreps"] = self.irreps
+        subGroup["transform"] = self.transform
         for field in self.data:
             subGroup[field] = self.data[field]
 

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -615,9 +615,14 @@ class SpinSpinCorrelator(Measurement):
         \param h5group Base HDF5 group. Data is stored in subgroup `h5group/self.savePath`.
         """
         subGroup = createH5Group(h5group, self.savePath)
-        subGroup["transform"] = self.transform
+        
         for name, correlator in self.correlators.items():
             subGroup[name] = correlator
+
+        if self.transform is None:
+            subGroup["transform"] = h5.Empty(dtype="complex")
+        else:
+            subGroup["transform"] = self.transform
 
     @classmethod
     def computeDerivedCorrelators(cls, measurements, correlators=None):

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -415,23 +415,34 @@ class SpinSpinCorrelator(Measurement):
     Tabulate spin-spin correlators.
     """
 
-    ##! Set of names of all possible elementary spin-spin correlators.
+    ## Set of names of all possible elementary spin-spin correlators.
     CORRELATOR_NAMES = {"np_np", "nh_np", "np_nh", "nh_nh",
                         "Splus_Sminus", "Sminus_Splus",
                         '++_--', '--_++'}
 
-    ##! Set of names of derived correlators that can be constructed from spin-spin correlators.
+    ## Set of names of derived correlators that can be constructed from spin-spin correlators.
     DERIVED_CORRELATOR_NAMES_SPIN_ONLY = {"S1_S1", "S1_S2", "rho_rho", "rho_n", "n_rho", "n_n"}
 
-    ##! Set of names of derived correlators that need one-point correlators to be constructed.
+    ## Set of names of derived correlators that need one-point correlators to be constructed.
     DERIVED_CORRELATOR_NAMES_ONE_POINT = {"S0_S0", "S0_S3", "S3_S0", "S3_S3"}
 
-    ##! Set of names of all derived correlators
+    ## Set of names of all derived correlators
     DERIVED_CORRELATOR_NAMES = {*DERIVED_CORRELATOR_NAMES_SPIN_ONLY,
                                 *DERIVED_CORRELATOR_NAMES_ONE_POINT}
 
     def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None),
                  transform=None, sigmaKappa=-1, correlators=None):
+        r"""!
+        \param particleAllToAll propagator.AllToAll for particles.
+        \param holesAllToAll propagator.AllToAll for holes.
+        \param savePath Path in the output file where results are saved.
+        \param configSlice `slice` indicating which configurations to measure on.
+        \param transform Transformation matrix applied to correlators in position space.
+        \param sigmaKappa \f$\sigma_\kappa\f$ from the fermion action.
+        \param correlators Iterable of names of correlators to compute.
+                           Defaults to SpinSpinCorrelator.CORRELATOR_NAMES.
+        """
+
         super().__init__(savePath, configSlice)
 
         if correlators is None:

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -21,7 +21,7 @@ which can be rewritten as \f$ \rho_x = 1–2 S^0_x\f$, where the \f$0^{th}\f$ Pa
 
 Rewriting those operators into the Isle basis,
 \f{align}{
-    \rho_x &= n^a_x–n^b_x = a_x^\dagger a – b_x^\dagger b                                       \\
+    \rho_x &= n^a_x–n^b_x = a_x^\dagger a_x – b_x^\dagger b_x                                       \\
     S^0_x &= \frac{1}{2} \left[ a_x a_x^\dagger – b_x b_x^\dagger +1 \right]                    \\
     S^1_x &= \frac{1}{2} (–\sigma_\kappa)^x \left[ b_x^\dagger a_x^\dagger + a_x b_x \right]    \\
     S^2_x &= \frac{i}{2} (–\sigma_\kappa)^x \left[ b_x^\dagger a_x^\dagger – a_x b_x \right]    \\
@@ -101,117 +101,148 @@ Now we can write correlation functions
 \f]
 and we don't need to track time separately, until we start analyzing how to actually use this correlation function.
 
-The simplest correlation function is \f$C^{11}\f$,
+The simplest correlation function is \f$C^{+–}_{xy}\f$,
 \f{align}{
-    \left\langle S^{1}_{x} S^{1}_{y}{}^\dagger \right\rangle
+    C^{+–}_{xy}     = \left\langle S^+_x S^–_y \right\rangle
+                    = (–\sigma_\kappa)^{x+y}\left\langle a_x b_x b_y^\dagger a_y^\dagger \right\rangle
+                &   = (-\sigma_\kappa)^{x+y}\left\langle P_{xy} H_{xy} \right\rangle
+                \\
+    C^{–+}_{xy}     = \left\langle S^–_x S^+_y \right\rangle
+                    = (–\sigma_\kappa)^{x+y}\left\langle a_x^\dagger b_x^\dagger b_y a_y \right\rangle
+                &   = (–\sigma_\kappa)^{x+y}\left\langle (\delta_{yx} – b_y b_x^\dagger)(\delta_{yx} – a_y a_x^\dagger) \right\rangle
+                \\
+                &   = (–\sigma_\kappa)^{x+y}\left\langle (\delta_{yx} – H_{yx})(\delta_{yx} – P_{yx}) \right\rangle
+\f}
+and \f$C^{–+}\f$, where we have used anticommutator rules to push all the daggered operators to the right to apply the Wick contraction rule,
+contracting particles into \f$P\f$ propagators and holes into \f$H\f$ propagators.
+
+Also simple (to write) are correlations between number operators,
+\f{align}{
+    C^{ph}_{xy}     = \left\langle N^p_x N^h_y \right\rangle
+                    = \left\langle (\delta_{xx} - a_x a_x^\dagger) (\delta_{yy} - b_y b_y^\dagger) \right\rangle
+                &   = \left\langle (\delta_{xx} - P_{xx}) (\delta_{yy} - H_{yy}) \right\rangle
+                \\
+    C^{pp}_{xy}     = \left\langle N^p_x N^p_y \right\rangle
+                    = \left\langle (\delta_{xx} - a_x a_x^\dagger) (\delta_{yy} - a_y a_y^\dagger) \right\rangle
+                &   = \left\langle \delta_{xx}\delta_{yy} - \delta_{xx} a_y a_y^\dagger - a_x a_x^\dagger \delta_{yy} + a_x a_x^\dagger a_y a_y^\dagger \right\rangle
+                \\
+                &   = \left\langle \delta_{xx}\delta_{yy} - \delta_{xx} a_y a_y^\dagger - a_x a_x^\dagger \delta_{yy} + a_x (\delta_{yx} - a_y a_x^\dagger) a_y^\dagger \right\rangle
+                \\
+                &   = \left\langle \delta_{xx}\delta_{yy} - \delta_{xx} P_{yy} - P_{xx} \delta_{yy} + \delta_{yx} P_{xy} – P_{xy} P_{yx} + P_{xx} P_{yy}  \right\rangle
+\f}
+and what we get by exchanging particles with holes,
+\f{align}{
+    C^{hp}_{xy}     = \left\langle N^h_x N^p_y \right\rangle
+                &   = \left\langle (\delta_{xx} - H_{xx}) (\delta_{yy} - P_{yy}) \right\rangle
+                \\
+    C^{hh}_{xy}     = \left\langle N^p_x N^p_y \right\rangle
+                &   = \left\langle \delta_{xx}\delta_{yy} - \delta_{xx} H_{yy} - H_{xx} \delta_{yy} + \delta_{yx} H_{xy} – H_{xy} H_{yx} + H_{xx} H_{yy}  \right\rangle
+\f}
+though these are more complicated to _compute_ because they have so-called disconnected diagrams.
+
+We can build correlations between the spin operators themselves.
+For example,
+\f{align}{
+    C^{11} = \left\langle S^{1}_{x} S^{1}_{y}{} \right\rangle
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle \left[ b_x^\dagger a_x^\dagger + a_x b_x \right] \left[ b_y^\dagger a_y^\dagger + a_y b_y \right] \right\rangle \\
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle a_x b_x a_y b_y + a_x b_x b_y^\dagger a_y^\dagger + b_x^\dagger a_x^\dagger a_y b_y + b_x^\dagger a_x^\dagger b_y^\dagger a_y^\dagger \right\rangle \\
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle a_x a_y^\dagger b_x b_y^\dagger + a_x^\dagger a_y b_x^\dagger b_y \right\rangle \\
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle a_x a_y^\dagger b_x b_y^\dagger + (\delta_{yx} – a_y a_x^\dagger)(\delta_{yx} – b_y b_x^\dagger) \right\rangle \\
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle P_{xy} H_{xy} + (\delta_{yx} – P_{yx})(\delta_{yx} – H_{yx}) \right\rangle \\
 \f}
-where we have taken advantage of the anticommutator rules,
-the fact that we will only get a non-zero result if we have the same number of \f$a\f$s as \f$a^\dagger\f$s (and likewise for \f$b\f$),
-and used the fact that the Wick contraction of \f$a_x a_y^\dagger = (M^p)^{–1}_{xy} \equiv P_{xy}\f$, defining \f$P\f$,
-and similarly for holes \f$b_x b_y^\dagger = (M^h)^{–1}_{xy} \equiv H_{xy}\f$.
-
 Computing \f$C^{22}_{xy}\f$ requires
 \f{align}{
-    \left\langle S^{2}_{x} S^{2}_{y}{}^\dagger \right\rangle
+    \left\langle S^{2}_{x} S^{2}_{y} \right\rangle
     &= \frac{1}{4} (–\sigma_\kappa)^{x+y} \left\langle \left[ b_x^\dagger a_x^\dagger – a_x b_x \right] \left[ a_y b_y – b_y^\dagger a_y^\dagger \right] \right\rangle \\
 \f}
-and when you write out all the operators in their complete glory, you find that you reproduce the non-vanishing operator content in \f$\left\langle S^{1}_{x} S^{1}_{y}{}^\dagger \right\rangle\f$,
-so \f$C^{22}_{xy} = C^{11}_{xy}\f$ (the vanishing operators have the opposite sign).
+and when you write out all the operators in their complete glory, you find that you reproduce the non-vanishing operator content in \f$\left\langle S^{1}_{x} S^{1}_{y} \right\rangle\f$,
+so \f$C^{22}_{xy} = C^{11}_{xy}\f$ (the vanishing operators have the opposite sign) configuration-by-configuration.
 
-We now move to \f$C^{33}_{xy}\f$, which is less trivial because of terms like \f$aa^\dagger\f$ in the individual operators,
-so that there are terms with four \f$a\f$ operators, and so-called disconnected diagrams:
-\f{align}{
-    \left\langle S^{3}_{x} S^{3}_{y}{}^\dagger \right\rangle
-    &= \frac{1}{4} \left\langle \left[ a_x a_x^\dagger + b_x b_x^\dagger –1 \right] \left[ a_y a_y^\dagger + b_y b_y^\dagger –1 \right] \right\rangle \\
-    &= \frac{1}{4} \left\langle a_x a_x^\dagger a_y a_y^\dagger + a_x a_x^\dagger b_y b_y^\dagger – a_x a_x^\dagger – a_y a_y^\dagger + (a \leftrightarrow b) +1 \right\rangle \\
-    &= \frac{1}{4} \left\langle a_x (\delta_{yx} – a_y a_x^\dagger ) a_y^\dagger + a_x a_x^\dagger b_y b_y^\dagger – a_x a_x^\dagger – a_y a_y^\dagger + (a \leftrightarrow b) +1 \right\rangle \\
-    &= \frac{1}{4} \left\langle – a_x a_y a_x^\dagger a_y^\dagger + a_x a_x^\dagger b_y b_y^\dagger + a_x a_y^\dagger \delta_{yx} – a_x a_x^\dagger – a_y a_y^\dagger + (a \leftrightarrow b) +1 \right\rangle \\
-    &= \frac{1}{4} \left\langle P_{xx}P_{yy} – P_{yx} P_{xy} + P_{xx} H_{yy} + P_{xy} – P_{xx} – P_{yy} + (P \leftrightarrow H) + 1 \right\rangle
-\f}
+In fact, using the definition of the spin-raising and -lowering operators, one finds
+\f[
+    C^{11}_{xy} + C^{22}_{xy}
+    =
+    \frac{1}{2}\left(C^{+–}_{xy}+C^{–+}_{xy}\right)
+\f]
+so that
+\f[
+    C^{11}_{xy} = C^{22}_{xy}
+    =
+    \frac{1}{4}\left(C^{+–}_{xy}+C^{–+}_{xy}\right)
+\f]
+Similarly, knowing that the four-dagger and no-dagger terms vanish, it is easy to show
+\f[
+         \left\langle S^{1}_{x}S^{2}_y\right\rangle
+    =
+        –\left\langle S^{2}_{x}S^{1}_y\right\rangle
+\f]
+(again, because the four- and no-dagger terms vanish) so that
+\f[
+    C^{12}_{xy} = – C^{21}_{xy}
+    =
+    \frac{i}{4}\left(C^{+–}_{xy}–C^{–+}_{xy}\right)
+\f]
+because
+\f[
+    C^{12}_{xy}+C^{21}_{xy} = \frac{i}{2} \left(C^{+–}_{xy} – C^{–+}_{xy}\right).
+\f]
+These mixed-spin correlators are not defined in Buividovich et al.
 
-We can also calculate the charge-charge correlator,
+The other two spins \f$S^0\f$ and \f$S^3\f$ do not enjoy such simplifications because
+each term in those operators can be contracted with itself, so there are no zero- or four-dagger
+operators which may be dropped from the Wick contractions.
+We are stuck computing four correlators and taking advantage of the one-point functions,
 \f{align}{
-    \left\langle \rho_x \rho_y^\dagger \right\rangle
-     = \left\langle (1–2S_x^0) (1–2S_y^0) \right\rangle
-    &= \left\langle 1 – 2 S_x^0 – 2 S_y^0 + 4 S_x^0 S_y^0 \right\rangle  \\
-    &= \left\langle 1 –(a_x a_x^\dagger – b_x b_x^\dagger + 1) – (a_y a_y^\dagger – b_y b_y^\dagger + 1) + (a_x a_x^\dagger – b_x b_x^\dagger + 1)(a_y a_y^\dagger – b_y b_y^\dagger + 1) \right\rangle \\
-    &= \left\langle a_x a_x^\dagger a_y a_y^\dagger – a_x a_x^\dagger b_y b_y^\dagger – b_x b_x^\dagger a_y a_y^\dagger + b_x b_x^\dagger b_y b_y^\dagger \right\rangle \\
-    &= \left\langle a_x (\delta_{yx} – a_y a_x^\dagger ) a_y^\dagger – a_x a_x^\dagger b_y b_y^\dagger – b_x b_x^\dagger a_y a_y^\dagger + b_x (\delta_{yx} – b_y b_x^\dagger) b_y^\dagger \right\rangle \\
-    &= \left\langle P_{xx}P_{yy} – P_{xy}P_{yx} + P_{xy}\delta_{yx} – P_{xx}H_{yy} + (P \leftrightarrow H) \right\rangle
+        C^{00}_{xy} &= \frac{1}{4}\left(
+        C^{pp}_{xy} + C^{hh}_{xy} - C^{ph}_{xy} - C^{hp}_{xy}
+        +
+        \left\langle 1 -N^p_x - N^p_y+ N^h_x +N^h_y \right\rangle
+        \right)
+        \\
+    C^{03}_{xy} &= \frac{1}{4}\left(
+        C^{pp}_{xy} - C^{hh}_{xy} + C^{ph}_{xy} - C^{hp}_{xy}
+        +
+        \left\langle 1 - N^p_x - N^p_y + N^h_x - N^h_y\right\rangle
+        \right)
+        \\
+    C^{30}_{xy} &= \frac{1}{4}\left(
+        C^{pp}_{xy} - C^{hh}_{xy} - C^{ph}_{xy} + C^{hp}_{xy}
+        +
+        \left\langle 1 - N^p_x - N^p_y - N^h_x + N^h_y \right\rangle
+        \right)
+        \\
+    C^{33}_{xy} &= \frac{1}{4}\left(
+        C^{pp}_{xy} + C^{hh}_{xy} + C^{ph}_{xy} + C^{hp}_{xy}
+        +
+        \left\langle 1 - N^p_x - N^p_y - N^h_x - N^h_y \right\rangle
+        \right)
+        \\
+    \text{and we define }
+    C^{\rho\rho}_{xy} &= C^{pp}_{xy} + C^{hh}_{xy} - C^{ph}_{xy} - C^{hp}_{xy}
 \f}
+the correlator between two charge density operators \f$C^{\rho\rho}_{xy}=\left\langle\rho_x\rho_y\right\rangle\f$.
+(In the above relations that require one-point functions 1 indicates a matrix full of ones---not an identity matrix in x and y.  Similarly \f$N_x\f$ changes in x but is constant in y, and vice-versa for \f$N_y\f$.)
 
-Something left undefined in Buividovich et al. are the mixed correlators, \f$C^{12}_{xy}\f$, which requires
-\f{align}{
-    \left\langle S^{1}_{x} S^{2}_{y}{}^\dagger \right\rangle
-    &= –\frac{i}{4}(–\sigma_\kappa)^{x+y} \left\langle \left[ b_x^\dagger a_x^\dagger + a_x b_x \right] \left[ a_y b_y – b_y^\dagger a_y^\dagger \right] \right\rangle   \\
-    &= –\frac{i}{4}(–\sigma_\kappa)^{x+y} \left\langle b_x^\dagger a_x^\dagger a_y b_y – a_x b_x b_y^\dagger a_y^\dagger + a_x b_x a_y b_y – b_x^\dagger a_x^\dagger b_y^\dagger a_y^\dagger \right\rangle   \\
-    &= –\frac{i}{4}(–\sigma_\kappa)^{x+y} \left\langle b_x^\dagger b_y a_x^\dagger a_y – b_x b_y^\dagger a_x a_y^\dagger \right\rangle   \\
-    &= –\frac{i}{4}(–\sigma_\kappa)^{x+y} \left\langle (\delta_{yx} – b_y b_x^\dagger) (\delta_{yx} – a_y a_x^\dagger) – b_x b_y^\dagger a_x a_y^\dagger \right\rangle   \\
-    &= –\frac{i}{4}(–\sigma_\kappa)^{x+y} \left\langle (\delta_{yx} – H_{yx}) (\delta_{yx} – P_{yx}) – H_{xy} P_{xy} \right\rangle   \\
-\f}
-and \f$C^{03}_{xy}\f$, requiring
-\f{align}{
-    \left\langle S^{0}_{x} S^{3}_{y}{}^\dagger \right\rangle
-    &= \frac{1}{4} \left\langle \left[ a_x a_x^\dagger – b_x b_x^\dagger +1 \right] \left[ a_x a_x^\dagger + b_x b_x^\dagger –1 \right] \right\rangle \\
-    &= \frac{1}{4} \left\langle P_{xx}P_{yy} – P_{xy}P_{yx} + P_{xx}H_{yy} – H_{xx}P_{yy} – H_{xx} H_{yy} + H_{xy} H_{yx} + P_{xy} – P_{xx} + P_{yy} – H_{xy} + H_{xx} + H_{yy} – 1\right\rangle
-\f}
-while \f$C^{21}_{xy}\f$ and \f$C^{30}_{xy}\f$ are defined analogously.
-Once the all-dagger or no-dagger operators are dropped, it is easy to see that
-\f{align}{
-    \left\langle S^1_x S^2_y{}^\dagger \right\rangle &= – \left\langle S^2_x S^1_y{}^\dagger\right\rangle
-\f}
-but unfortunately no such simple relation holds between (0,3) and (3,0).
-
-Note that 1 and 2 cannot mix with 0 or 3 because each term would not have the right constituent operator content to contract completely.  This is very curious, and seems kind of broken.
+Note that 1 and 2 cannot mix with 0 or 3 because each term would not have the right constituent operator content to contract completely.  This is very curious.
 I think if we had a spin chemical potential that mixed \f$a\f$ and \f$b\f$ operators, such as \f$\mu S^1\f$, we would not be able to split the operators into two species, because the bilinear piece would allow one species to mix with the other while propagating,
 so that the contractions, rather than considering \f$a\f$ and \f$b\f$ separately, would consider \f$c\f$ operators with more entries and the chemical potential would introduce an off-diagonal component.
 Working out the details of this is a question for a different time, however.
 
-We can also think of correlators between \f$S^+\f$ and \f$S^–\f$,
-\f{align}{
-    \left\langle S^+_x S^–_y \right\rangle
-        &= (–\sigma_\kappa)^{x+y}\left\langle a_x b_x b^\dagger_y a^\dagger_y \right\rangle \\
-        &= (–\sigma_\kappa)^{x+y}\left\langle P_{xy} H_{xy}\right\rangle    \\
-    \left\langle S^–_x S^+_y \right\rangle
-        &= (–\sigma_\kappa)^{x+y}\left\langle b^\dagger_x a^\dagger_x a_y b_y  \right\rangle \\
-        &= (–\sigma_\kappa)^{x+y}\left\langle (\delta_{yx}– b_y b^\dagger_x)(\delta_{yx} – a_y a^\dagger_x)  \right\rangle \\
-        &= (–\sigma_\kappa)^{x+y}\left\langle (\delta_{yx}– H_{yx})(\delta_{yx} – P_{yx})  \right\rangle \\
-\f}
-# TODO: These have a name; I should find it.
-At half filling on a bipartite lattice, the cost to create or destroy a spin from the vacuum should be equal and the correlators should match, in the limit of large statistics.
-
-We can similarly build correlators between \f$N^p\f$ and itself or \f$N^h\f$,
-\f{align}{
-    \left\langle N^p_x N^h_y{}^\dagger \right\rangle
-        &=  \left\langle a_x a^\dagger_x b_y b^\dagger_y \right\rangle \\
-        &=  \left\langle P_{xx} H_{yy} \right\rangle
-        \\
-    \left\langle N^p_x N^p_x{}^\dagger \right\rangle
-        &=  \left\langle a_x a^\dagger_x a_y a^\dagger_y \right\rangle \\
-        &=  \left\langle a_x (\delta_{yx} – a_y a^\dagger_x) a^\dagger_y \right\rangle \\
-        &=  \left\langle a_x a^\dagger_y – a_x a_y a^\dagger_x a^\dagger_y \right\rangle \\
-        &=  \left\langle P_{xy} – P_{xy}P_{yx} + P_{xx}P_{yy} \right\rangle
-\f}
-and we can interchange the p/h superscripts by changing the \f$P\f$ and \f$H\f$ propagators.
 
 # Conserved Quantities
 
 When the Hamiltonian takes a Hubbard-Coulomb-like form,
 \f[
-    H = \sum_{xy} a_x^\dagger K_{xy} a_y + b_x^\dagger K_{xy} b_y + \frac{1}{2} \sum_{xy} \rho_x V_{xy} \rho_y
+    H = \sum_{xy}–\left(a_x^\dagger K_{xy} a_y + \sigma_\kappa b_x^\dagger K_{xy} b_y\right) + \frac{1}{2} \sum_{xy} \rho_x V_{xy} \rho_y
 \f]
-some of the bilinears may be conserved.  For example, we can calculate the commutator
+some combinations of bilinears may be conserved.  For example, we can calculate the commutator
 \f{align}{
     [H, \rho_z]
-        &= \left[\sum_{xy} a_x^\dagger K_{xy} a_y + b_x^\dagger K_{xy} b_y, \rho_z\right]   \\
-        &= \sum_x – a_x^\dagger K_{xz} a_z + \sum_y a_z^\dagger K_{zy} a_y – \sigma_\kappa (a \leftrightarrow b) \\
+        &= \left[–\sum_{xy} a_x^\dagger K_{xy} a_y + \sigma_\kappa b_x^\dagger K_{xy} b_y, \rho_z\right]   \\
+        &= \left(\sum_x – a_x^\dagger K_{xz} a_z + \sum_y a_z^\dagger K_{zy} a_y\right) – \left(\sigma_\kappa (a \leftrightarrow b)\right) \\
 \f}
-where we immediately dropped the interaction term since the charge operator commutes with itself.
+where we immediately dropped the interaction term since the charge operator commutes with itself,
+and the relative minus sign between the particle and hole arises because particles and holes have opposite charge.
 If we sum \f$z\f$ over all space the two terms cancel, so that the total charge is conserved.
 One similarly finds the total spins conserved,
 \f[

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -605,37 +605,6 @@ class measurement(Measurement):
             subGroup[field] = self.data[field]
 
 
-def read(h5group):
-    r"""!
-    \param h5group HDF5 group which contains the data for this measurement.
-
-    \returns A dictionary of measurements and a transformation, \n
-    {   \n
-        `Splus_Sminus`: \f$S^+_{xf}S^-_{yi}\f$,                         \n
-        `Sminus_Splus`: \f$S^-_{xf}S^+_{yi}\f$,                         \n
-        `np_np`       : \f$n^p_{xf}n^p_{yi}\f$,                         \n
-        `np_nh`       : \f$n^p_{xf}n^h_{yi}\f$,                         \n
-        `nh_np`       : \f$n^h_{xf}n^p_{yi}\f$,                         \n
-        `nh_nh`       : \f$n^h_{xf}n^h_{yi}\f$,                         \n
-        `++_--`       : \f$(a^\dagger b)_{xf} (b^\dagger a)_{yi}\f$,    \n
-        `--_++`       : \f$(b^\dagger a)_{xf} (a^\dagger b)_{yi}\f$,    \n
-        `spinSpin-transform`: A transformation from position space to another space.
-    }
-    """
-
-    try:
-        data = {key: h5group[key][()] for key in h5group}
-
-        if type(data['transform']) is h5.Empty:
-            data['transform'] = None
-
-        data['spinSpin-transform'] = data['transform']
-        del data['transform']
-
-        return data
-    except:
-        raise KeyError(f"Problem reading spinSpinCorrelator measurements from {h5group.name}")
-
 def complete(measurements, correlators=["S1_S1", "S1_S2", "rho_rho", "rho_n", "n_rho", "n_n",
                                         "S3_S3", "S3_S0", "S0_S3", "S0_S0"
                                         ]):

--- a/src/isle/meas/spinSpinCorrelator.py
+++ b/src/isle/meas/spinSpinCorrelator.py
@@ -422,6 +422,16 @@ class SpinSpinCorrelator(Measurement):
                         "Splus_Sminus", "Sminus_Splus",
                         '++_--', '--_++'}
 
+    ##! Set of names of derived correlators that can be constructed from spin-spin correlators.
+    DERIVED_CORRELATOR_NAMES_SPIN_ONLY = {"S1_S1", "S1_S2", "rho_rho", "rho_n", "n_rho", "n_n"}
+
+    ##! Set of names of derived correlators that need one-point correlators to be constructed.
+    DERIVED_CORRELATOR_NAMES_ONE_POINT = {"S0_S0", "S0_S3", "S3_S0", "S3_S3"}
+
+    ##! Set of names of all derived correlators
+    DERIVED_CORRELATOR_NAMES = {*DERIVED_CORRELATOR_NAMES_SPIN_ONLY,
+                                *DERIVED_CORRELATOR_NAMES_ONE_POINT}
+
     def __init__(self, particleAllToAll, holeAllToAll, savePath, configSlice=(None, None, None),
                  transform=None, sigmaKappa=-1, correlators=None):
         super().__init__(savePath, configSlice)
@@ -606,7 +616,7 @@ class SpinSpinCorrelator(Measurement):
             subGroup[name] = correlator
 
 
-def computeDerivedCorrelators(measurements):
+def computeDerivedCorrelators(measurements, correlators=None):
     r"""!
     \param measurements a dictionary of measurements that has measurements of `"Splus_Sminus"`,
     `"Sminus_Splus"`, `"np_np"`, `"np_nh"`, `"nh_np"`, and `"nh_nh"` (and other fields are allowed).
@@ -617,29 +627,43 @@ def computeDerivedCorrelators(measurements):
 
     You can sensibly do this on vectors of bootstrapped averages, since everything is linear.
 
-    \returns the passed dictionary of measurements, with additional reconstructed correlators
+    \returns `dict` with additional reconstructed correlators
     `"S1_S1"`, `"S1_S2"`, `"rho_rho"`, `"rho_n"`, `"n_rho"`, `n_n`.  If `"np"` and `"nh"` are available,
     also constructed are `"S0_S0"`, `"S0_S3"`, `"S3_S0"`, and `"S3_S3"`.
     """
 
-    rest = dict()
-
-    # These are easy to think about, if one is measured they are all measured.
-    rest["S1_S1"]   = 0.25 *(measurements["Splus_Sminus"] + measurements["Sminus_Splus"])
-    rest["S1_S2"]   = 0.25j*(measurements["Splus_Sminus"] - measurements["Sminus_Splus"])
-    rest["rho_rho"] = measurements["np_np"] + measurements["nh_nh"] - measurements["np_nh"] - measurements["nh_np"]
-    rest["rho_n"]   = measurements["np_np"] - measurements["nh_nh"] + measurements["np_nh"] - measurements["nh_np"]
-    rest["n_rho"]   = measurements["np_np"] - measurements["nh_nh"] - measurements["np_nh"] + measurements["nh_np"]
-    rest["n_n"]     = measurements["np_np"] + measurements["nh_nh"] + measurements["np_nh"] + measurements["nh_np"]
-
     log = getLogger(__name__)
 
-    if "np" in measurements and "nh" in measurements:
-        log.info("Constructing bilinears that require one-point measurements.")
+    if correlators is None:
+        if "np" in measurements and "nh" in measurements:
+            correlators = SpinSpinCorrelator.DERIVED_CORRELATOR_NAMES
+            log.info("Selecting full derived spin-spin correlators: %s", correlators)
+        else:
+            correlators = SpinSpinCorrelator.DERIVED_CORRELATOR_NAMES_SPIN_ONLY
+            log.info("Selecting only partial derived spin-spin correlators, "
+                     "no one point data is available: %s", correlators)
 
+    derived = dict()
+
+    # These are easy to think about, if one is measured they are all measured.
+    if "S1_S1" in correlators:
+        derived["S1_S1"] = 0.25 *(measurements["Splus_Sminus"] + measurements["Sminus_Splus"])
+    if "S1_S2" in correlators:
+        derived["S1_S2"] = 0.25j*(measurements["Splus_Sminus"] - measurements["Sminus_Splus"])
+    if "rho_rho" in correlators:
+        derived["rho_rho"] = measurements["np_np"] + measurements["nh_nh"] - measurements["np_nh"] - measurements["nh_np"]
+    if "rho_n" in correlators:
+        derived["rho_n"] = measurements["np_np"] - measurements["nh_nh"] + measurements["np_nh"] - measurements["nh_np"]
+    if "n_rho" in correlators:
+        derived["n_rho"] = measurements["np_np"] - measurements["nh_nh"] - measurements["np_nh"] + measurements["nh_np"]
+    if "n_n" in correlators:
+        derived["n_n"] = measurements["np_np"] + measurements["nh_nh"] + measurements["np_nh"] + measurements["nh_np"]
+
+    if any(name in correlators for name in SpinSpinCorrelator.DERIVED_CORRELATOR_NAMES_ONE_POINT):
         # TODO: These are hard to think about generally, if they're not measured with equal frequency.
         # NB:   This contains the assumption that they're measured at *the same* frequency
         nm = measurements["np"].shape[0]    # number of measurements
+        assert nm == measurements["np_np"].shape[0]
         nx = measurements["np"].shape[-1]
         nt = measurements["Splus_Sminus"].shape[-1]
 
@@ -651,12 +675,13 @@ def computeDerivedCorrelators(measurements):
         npy = np.einsum('ay,xt->axyt', measurements["np"], constant, optimize="optimal")
         nhy = np.einsum('ay,xt->axyt', measurements["nh"], constant, optimize="optimal")
 
-        rest["S0_S0"] = 0.25*(rest["rho_rho"] + one - npx - npy + nhx + nhy)
-        rest["S0_S3"] = 0.25*(rest["rho_n"]   + one - npx - npy + nhx - nhy)
-        rest["S3_S0"] = 0.25*(rest["n_rho"]   + one - npx - npy - nhx + nhy)
-        rest["S3_S3"] = 0.25*(rest["n_n"]     + one - npx - npy - nhx - nhy)
+        if "S0_S0" in correlators:
+            derived["S0_S0"] = 0.25*(derived["rho_rho"] + one - npx - npy + nhx + nhy)
+        if "S0_S3" in correlators:
+            derived["S0_S3"] = 0.25*(derived["rho_n"]   + one - npx - npy + nhx - nhy)
+        if "S3_S0" in correlators:
+            derived["S3_S0"] = 0.25*(derived["n_rho"]   + one - npx - npy - nhx + nhy)
+        if "S3_S3" in correlators:
+            derived["S3_S3"] = 0.25*(derived["n_n"]     + one - npx - npy - nhx - nhy)
 
-    else:
-        log.info("One-point measurements are needed to construct S3_S3, S3_S0, S0_S3, S0_S0 bilinears.")
-
-    return {**measurements, **rest}
+    return derived


### PR DESCRIPTION
_THIS IS A BREAKING CHANGE_

Two changes are breaking.  

1.  First, i changed the name of the `projector` argument to `transform` argument, which I think is a better name and will wind up being made across the observables in time.  The reason for the name change is twofold: i think that the transform need not be unitary, in that it could be to a subspace, and also a unitary transformation isn't a projector!

2.  The observables that get calculated are different!  The correlation functions are `Splus_Sminus`, `Sminus_Splus`, `np_np`, `np_nh`, `nh_np`, `nh_nh`, `++_––`, `––_++`, `S1_S1`, `S1_S2`, `rho_rho`, `rho_n`, `n_rho`, and `n_n`.  `n=np+nh`, `++` and `––` are charge-±2 bilinears

No longer computed is `S3_S3`.  Never computed, before or with this change, is `S0_S3`, `S3_S0`, `S0_S0`.  As explained in the updated documentation, these can be constructed from the computed correlators and the one-point functions.  I propose adding this construction to archipelago, as it can be done in the analysis step.  However, I can add it to this observable, to keep it self-contained, if that's better.

Exact correctness:  i believe I have double-checked that everything now matches exact results.  I found that running the example (U=2, b=3) in the documentation for the triangular lattice and diagonal discretization really did well, with just dumb reweighting and no fancy analysis (thanks to the 'easy' parameters).